### PR TITLE
feature:redis client支持读请求到从节点

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-contrib/sessions v0.0.4
 	github.com/gin-gonic/gin v1.7.7
-	github.com/go-redis/redis/v7 v7.4.1
+	github.com/go-redis/redis/v8 v8.11.0
 	github.com/go-zookeeper/zk v1.0.2
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/go-cmp v0.5.8
@@ -66,6 +66,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/eapache/go-resiliency v1.2.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
 	github.com/eapache/queue v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/eapache/go-resiliency v1.2.0 h1:v7g92e/KSN71Rq7vSThKaWIq68fL4YHvWyiUKorFR1Q=
 github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
@@ -192,8 +194,8 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
-github.com/go-redis/redis/v7 v7.4.1 h1:PASvf36gyUpr2zdOUS/9Zqc80GbM+9BDyiJSJDDOrTI=
-github.com/go-redis/redis/v7 v7.4.1/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
+github.com/go-redis/redis/v8 v8.11.0 h1:O1Td0mQ8UFChQ3N9zFQqo6kTU2cJ+/it88gDB+zg0wo=
+github.com/go-redis/redis/v8 v8.11.0/go.mod h1:DLomh7y2e3ggQXQLd1YgmvIfecPJoFl7WU5SOQ/r06M=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
@@ -412,6 +414,7 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.15.0/go.mod h1:hF8qUzuuC8DJGygJH3726JnCZX4MYbRB8yFfISqnKUg=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.6 h1:Fx2POJZfKRQcM1pH49qSZiYeu319wji004qX+GDovrU=
@@ -419,6 +422,7 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
 github.com/onsi/gomega v1.20.2 h1:8uQq0zMgLEfa0vRrrBgaJF2gyW9Da9BmfGV+OyUzfkY=
 github.com/onsi/gomega v1.20.2/go.mod h1:iYAIXgPSaDHak0LCMA+AWBpIKBr8WZicMxnE8luStNc=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
@@ -655,6 +659,7 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/src/common/lock/lock.go
+++ b/src/common/lock/lock.go
@@ -130,10 +130,10 @@ func (l *mlock) MLock(rid string, retry int, expire time.Duration, keys ...StrFo
 			key := fmt.Sprintf("%s%s", common.BKCacheKeyV3Prefix, k)
 			uuid := xid.New().String()
 			l.keys = append(l.keys, key)
-			pipe.SetNX(key, uuid, 0)
-			pipe.Expire(key, expire)
+			pipe.SetNX(context.Background(), key, uuid, 0)
+			pipe.Expire(context.Background(), key, expire)
 		}
-		res, err := pipe.Exec()
+		res, err := pipe.Exec(context.Background())
 		if err != nil {
 			// exec error try it again
 			continue

--- a/src/common/lock/lock_test.go
+++ b/src/common/lock/lock_test.go
@@ -8,7 +8,7 @@ import (
 
 	"configcenter/src/storage/dal/redis"
 
-	rawRedis "github.com/go-redis/redis/v7"
+	rawRedis "github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/require"
 )
 

--- a/src/scene_server/datacollection/collections/porter.go
+++ b/src/scene_server/datacollection/collections/porter.go
@@ -267,12 +267,12 @@ func (p *SimplePorter) collectLoop() error {
 			// ReceiveMessage returns a Message or error ignoring Subscription or Pong
 			// messages. It automatically reconnects to Redis Server and resubscribes
 			// to topics in case of network errors.
-			newMsg, err := subChan.ReceiveMessage()
+			newMsg, err := subChan.ReceiveMessage(context.Background())
 			if err != nil {
 				blog.Errorf("SimplePorter[%s]| receive topics[%+v] message failed, %+v", p.name, p.topics, err)
 
 				// internal errors, unsubscribe and try to sub-recv again.
-				subChan.Unsubscribe(p.topics...)
+				subChan.Unsubscribe(context.Background(), p.topics...)
 				subChan.Close()
 				break
 			}

--- a/src/source_controller/cacheservice/cache/mainline/custom.go
+++ b/src/source_controller/cacheservice/cache/mainline/custom.go
@@ -129,9 +129,9 @@ func (m *customLevel) reconcileCustomWatch(rid string, rank []string) error {
 			// delete resume token and start time at first, because it should not be reused.
 			key := newCustomKey(obj)
 			pipe := m.rds.Pipeline()
-			pipe.Del(key.resumeAtTimeKey())
-			pipe.Del(key.resumeTokenKey())
-			_, err := pipe.Exec()
+			pipe.Del(context.Background(), key.resumeAtTimeKey())
+			pipe.Del(context.Background(), key.resumeTokenKey())
+			_, err := pipe.Exec(context.Background())
 			if err != nil {
 				blog.Errorf("delete resume token and start time key failed, err: %v, rid: %s", err, key)
 				// try next round.

--- a/src/source_controller/cacheservice/cache/mainline/handler.go
+++ b/src/source_controller/cacheservice/cache/mainline/handler.go
@@ -51,9 +51,9 @@ func (t *tokenHandler) SetLastWatchToken(_ context.Context, token string) error 
 	}
 
 	pipe := t.rds.Pipeline()
-	pipe.Set(t.key.resumeTokenKey(), token, 0)
-	pipe.Set(t.key.resumeAtTimeKey(), string(atTime), 0)
-	_, err = pipe.Exec()
+	pipe.Set(context.Background(), t.key.resumeTokenKey(), token, 0)
+	pipe.Set(context.Background(), t.key.resumeAtTimeKey(), string(atTime), 0)
+	_, err = pipe.Exec(context.Background())
 	if err != nil {
 		return err
 	}
@@ -107,9 +107,9 @@ func (t *tokenHandler) resetWatchTokenWithTimestamp(startAtTime types.TimeStamp)
 	}
 
 	pipe := t.rds.Pipeline()
-	pipe.Set(t.key.resumeTokenKey(), "", 0)
-	pipe.Set(t.key.resumeAtTimeKey(), string(atTime), 0)
-	_, err = pipe.Exec()
+	pipe.Set(context.Background(), t.key.resumeTokenKey(), "", 0)
+	pipe.Set(context.Background(), t.key.resumeAtTimeKey(), string(atTime), 0)
+	_, err = pipe.Exec(context.Background())
 	if err != nil {
 		return err
 	}

--- a/src/source_controller/cacheservice/cache/mainline/logic.go
+++ b/src/source_controller/cacheservice/cache/mainline/logic.go
@@ -79,7 +79,7 @@ func (c *Client) listBusinessWithRefreshCache(ctx context.Context, ids []int64, 
 			return nil, err
 		}
 
-		pipe.Set(bizKey.detailKey(id), js, detailTTLDuration)
+		pipe.Set(context.Background(), bizKey.detailKey(id), js, detailTTLDuration)
 
 		all[idx] = string(js)
 		if len(fields) != 0 {
@@ -87,7 +87,7 @@ func (c *Client) listBusinessWithRefreshCache(ctx context.Context, ids []int64, 
 		}
 	}
 
-	_, err = pipe.Exec()
+	_, err = pipe.Exec(context.Background())
 	if err != nil {
 		blog.Errorf("update biz cache failed, err: %v, rid: %v", err, rid)
 		// do not return, cache will be refresh for the next round
@@ -126,7 +126,7 @@ func (c *Client) listModuleWithRefreshCache(ctx context.Context, ids []int64, fi
 			return nil, err
 		}
 
-		pipe.Set(moduleKey.detailKey(id), js, detailTTLDuration)
+		pipe.Set(context.Background(), moduleKey.detailKey(id), js, detailTTLDuration)
 
 		all[idx] = string(js)
 		if len(fields) != 0 {
@@ -134,7 +134,7 @@ func (c *Client) listModuleWithRefreshCache(ctx context.Context, ids []int64, fi
 		}
 	}
 
-	_, err = pipe.Exec()
+	_, err = pipe.Exec(context.Background())
 	if err != nil {
 		blog.Errorf("update module cache failed, err: %v, rid: %v", err, rid)
 		// do not return, cache will be refresh for the next round
@@ -173,7 +173,7 @@ func (c *Client) listSetWithRefreshCache(ctx context.Context, ids []int64, field
 			return nil, err
 		}
 
-		pipe.Set(setKey.detailKey(id), js, detailTTLDuration)
+		pipe.Set(context.Background(), setKey.detailKey(id), js, detailTTLDuration)
 
 		all[idx] = string(js)
 		if len(fields) != 0 {
@@ -181,7 +181,7 @@ func (c *Client) listSetWithRefreshCache(ctx context.Context, ids []int64, field
 		}
 	}
 
-	_, err = pipe.Exec()
+	_, err = pipe.Exec(context.Background())
 	if err != nil {
 		blog.Errorf("update set cache failed, err: %v, rid: %v", err, rid)
 		// do not return, cache will be refresh for the next round
@@ -333,10 +333,10 @@ func (c *Client) listCustomLevelDetailWithRefreshCache(ctx context.Context, key 
 			return nil, err
 		}
 
-		pipe.Set(key.detailKey(id), js, detailTTLDuration)
+		pipe.Set(context.Background(), key.detailKey(id), js, detailTTLDuration)
 	}
 
-	_, err = pipe.Exec()
+	_, err = pipe.Exec(context.Background())
 	if err != nil {
 		blog.Errorf("update custom object instance cache failed, err: %v, rid: %v", err, rid)
 		// do not return, cache will be refresh for the next round

--- a/src/source_controller/cacheservice/event/flow/flow.go
+++ b/src/source_controller/cacheservice/event/flow/flow.go
@@ -241,7 +241,8 @@ func (f *Flow) doBatch(es []*types.Event) (retry bool) {
 
 		// if hit cursor conflict, the former cursor node's detail will be overwrite by the later one, so it
 		// is not needed to remove the overlapped cursor node's detail again.
-		pipe.Set(f.key.DetailKey(chainNode.Cursor), string(detailBytes), time.Duration(f.key.TTLSeconds())*time.Second)
+		pipe.Set(context.Background(), f.key.DetailKey(chainNode.Cursor), string(detailBytes),
+			time.Duration(f.key.TTLSeconds())*time.Second)
 
 		// validate if the cursor already exists in the batch, this happens when the concurrency is very high.
 		// which will generate the same operation event with same cluster time, and generate with the same cursor
@@ -277,7 +278,7 @@ func (f *Flow) doBatch(es []*types.Event) (retry bool) {
 	}
 
 	// store details at first, in case those watching cmdb events read chain when details are not inserted yet
-	if _, err := pipe.Exec(); err != nil {
+	if _, err := pipe.Exec(context.Background()); err != nil {
 		f.metrics.CollectRedisError()
 		blog.Errorf("run flow, but insert details for %s failed, oids: %+v, err: %v, rid: %s,", f.key.Collection(),
 			oids, err, rid)

--- a/src/source_controller/cacheservice/event/flow/instance_flow.go
+++ b/src/source_controller/cacheservice/event/flow/instance_flow.go
@@ -224,7 +224,8 @@ func (f *InstanceFlow) doBatch(es []*types.Event) (retry bool) {
 
 			// if hit cursor conflict, the former cursor node's detail will be overwrite by the later one, so it
 			// is not needed to remove the overlapped cursor node's detail again.
-			pipe.Set(key.DetailKey(chainNode.Cursor), string(detailBytes), time.Duration(key.TTLSeconds())*time.Second)
+			pipe.Set(context.Background(), key.DetailKey(chainNode.Cursor), string(detailBytes),
+				time.Duration(key.TTLSeconds())*time.Second)
 		}
 
 		if hitConflict {
@@ -251,7 +252,7 @@ func (f *InstanceFlow) doBatch(es []*types.Event) (retry bool) {
 	lastTokenData[common.BKStartAtTimeField] = lastChainNode.ClusterTime
 
 	// store details at first, in case those watching cmdb events read chain when details are not inserted yet
-	if _, err := pipe.Exec(); err != nil {
+	if _, err := pipe.Exec(context.Background()); err != nil {
 		f.metrics.CollectRedisError()
 		blog.Errorf("run flow, but insert details for %s failed, oids: %+v, err: %v, rid: %s,", f.key.Collection(),
 			oids, err, rid)

--- a/src/source_controller/cacheservice/event/mix-event/flow.go
+++ b/src/source_controller/cacheservice/event/mix-event/flow.go
@@ -225,7 +225,7 @@ func (f *MixEventFlow) handleEvents(events []*types.Event, lastTokenData mapstr.
 		if len(detailBytes) > 0 {
 			// if hit cursor conflict, the former cursor node's detail will be overwritten by the later one, so it
 			// is not needed to remove the overlapped cursor node's detail again.
-			pipe.Set(f.MixKey.DetailKey(chainNode.Cursor), string(detailBytes),
+			pipe.Set(context.Background(), f.MixKey.DetailKey(chainNode.Cursor), string(detailBytes),
 				time.Duration(f.MixKey.TTLSeconds())*time.Second)
 			needSaveDetails = true
 		}
@@ -254,7 +254,7 @@ func (f *MixEventFlow) handleEvents(events []*types.Event, lastTokenData mapstr.
 
 	// store details at first, in case those watching cmdb events read chain when details are not inserted yet
 	if needSaveDetails {
-		if _, err := pipe.Exec(); err != nil {
+		if _, err := pipe.Exec(context.Background()); err != nil {
 			f.metrics.CollectRedisError()
 			blog.Errorf("run flow, but insert details for %s failed, oids: %+v, err: %v, rid: %s,", f.Key.Collection(),
 				oids, err, rid)

--- a/src/storage/dal/mongo/local/txn_manager.go
+++ b/src/storage/dal/mongo/local/txn_manager.go
@@ -91,9 +91,9 @@ func (t *TxnManager) GenTxnNumber(sessionID string, ttl time.Duration) (int64, e
 	}
 	// we increase by step 1, so that we can calculate how many transaction has already
 	// be executed in a same session.
-	pip.SetNX(key, 0, ttl).Result()
-	incrBy := pip.IncrBy(key, 1)
-	_, err := pip.Exec()
+	pip.SetNX(context.Background(), key, 0, ttl).Result()
+	incrBy := pip.IncrBy(context.Background(), key, 1)
+	_, err := pip.Exec(context.Background())
 	if err != nil {
 		return 0, err
 	}

--- a/src/storage/dal/redis/README.md
+++ b/src/storage/dal/redis/README.md
@@ -1,6 +1,7 @@
 ## 实现方式
  - 通过对底层redis client的封装，实现接口Client来提供redis常用的一些操作
- - 当前封装的底层redis client是[go-redis](https://github.com/go-redis/redis/tree/v7)，git地址为<https://github.com/go-redis/redis/tree/v7>
+ - 当前封装的底层redis client是[go-redis](https://github.com/go-redis/redis/tree/v8)，git地址为<https://github.
+   com/go-redis/redis/tree/v8>
 
 ## 实现目的
 - 在底层redis client之上增加一层接口封装，该接口供上层调用，有利于代码的扩展性
@@ -18,7 +19,7 @@ import (
 
 	localRedis "configcenter/src/storage/dal/redis"
 
-	"github.com/go-redis/redis/v7"
+	"github.com/go-redis/redis/v8"
 )
 
 func main() {
@@ -51,9 +52,9 @@ func DBOps(cli localRedis.Client) {
 	key := "mykey"
 
 	pipe := cli.Pipeline()
-	pipe.Set("aaa", 99, 0)
-	pipe.Get("aaa")
-	vals, err := pipe.Exec()
+	pipe.Set(context.Background(), "aaa", 99, 0)
+	pipe.Get(context.Background(), "aaa")
+	vals, err := pipe.Exec(context.Background())
 	checkErr(err)
 	fmt.Println("Pipeline", vals)
 

--- a/src/storage/dal/redis/client.go
+++ b/src/storage/dal/redis/client.go
@@ -16,7 +16,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/go-redis/redis/v7"
+	"github.com/go-redis/redis/v8"
 )
 
 // Client is the interface for redis client
@@ -28,7 +28,8 @@ type Client interface {
 }
 
 type client struct {
-	cli *redis.Client
+	cli        *redis.Client
+	clusterCli *redis.ClusterClient
 }
 
 // NewClient returns a client to the Redis Server specified by Options
@@ -45,14 +46,21 @@ func NewFailoverClient(failoverOpt *redis.FailoverOptions) Client {
 	}
 }
 
+// NewFailoverClusterClient returns a client that supports routing read-only commands to a slave node.
+func NewFailoverClusterClient(failoverOpt *redis.FailoverOptions) Client {
+	return &client{
+		clusterCli: redis.NewFailoverClusterClient(failoverOpt),
+	}
+}
+
 // Subscribe TODO
 func (c *client) Subscribe(ctx context.Context, channels ...string) PubSub {
-	return c.cli.Subscribe(channels...)
+	return c.cli.Subscribe(ctx, channels...)
 }
 
 // PSubscribe TODO
 func (c *client) PSubscribe(ctx context.Context, channels ...string) PubSub {
-	return c.cli.PSubscribe(channels...)
+	return c.cli.PSubscribe(ctx, channels...)
 }
 
 // Pipeline TODO
@@ -62,12 +70,12 @@ func (c *client) Pipeline() Pipeliner {
 
 // BRPop TODO
 func (c *client) BRPop(ctx context.Context, timeout time.Duration, keys ...string) StringSliceResult {
-	return c.cli.BRPop(timeout, keys...)
+	return c.cli.BRPop(ctx, timeout, keys...)
 }
 
 // BRPopLPush TODO
 func (c *client) BRPopLPush(ctx context.Context, source, destination string, timeout time.Duration) StringResult {
-	return c.cli.BRPopLPush(source, destination, timeout)
+	return c.cli.BRPopLPush(ctx, source, destination, timeout)
 }
 
 // Close TODO
@@ -77,172 +85,172 @@ func (c *client) Close() error {
 
 // Del TODO
 func (c *client) Del(ctx context.Context, keys ...string) IntResult {
-	return c.cli.Del(keys...)
+	return c.cli.Del(ctx, keys...)
 }
 
 // Eval TODO
 func (c *client) Eval(ctx context.Context, script string, keys []string, args ...interface{}) Result {
-	return c.cli.Eval(script, keys, args...)
+	return c.cli.Eval(ctx, script, keys, args...)
 }
 
 // Exists TODO
 func (c *client) Exists(ctx context.Context, keys ...string) IntResult {
-	return c.cli.Exists(keys...)
+	return c.cli.Exists(ctx, keys...)
 }
 
 // Expire TODO
 func (c *client) Expire(ctx context.Context, key string, expiration time.Duration) BoolResult {
-	return c.cli.Expire(key, expiration)
+	return c.cli.Expire(ctx, key, expiration)
 }
 
 // FlushDB TODO
 func (c *client) FlushDB(ctx context.Context) StatusResult {
-	return c.cli.FlushDB()
+	return c.cli.FlushDB(ctx)
 }
 
 // Get TODO
 func (c *client) Get(ctx context.Context, key string) StringResult {
-	return c.cli.Get(key)
+	return c.cli.Get(ctx, key)
 }
 
 // HDel TODO
 func (c *client) HDel(ctx context.Context, key string, fields ...string) IntResult {
-	return c.cli.HDel(key, fields...)
+	return c.cli.HDel(ctx, key, fields...)
 }
 
 // HGet TODO
 func (c *client) HGet(ctx context.Context, key, field string) StringResult {
-	return c.cli.HGet(key, field)
+	return c.cli.HGet(ctx, key, field)
 }
 
 // HGetAll TODO
 func (c *client) HGetAll(ctx context.Context, key string) StringStringMapResult {
-	return c.cli.HGetAll(key)
+	return c.cli.HGetAll(ctx, key)
 }
 
 // HIncrBy TODO
 func (c *client) HIncrBy(ctx context.Context, key, field string, incr int64) IntResult {
-	return c.cli.HIncrBy(key, field, incr)
+	return c.cli.HIncrBy(ctx, key, field, incr)
 }
 
 // HKeys TODO
 func (c *client) HKeys(ctx context.Context, key string) StringSliceResult {
-	return c.cli.HKeys(key)
+	return c.cli.HKeys(ctx, key)
 }
 
 // HMGet TODO
 func (c *client) HMGet(ctx context.Context, key string, fields ...string) SliceResult {
-	return c.cli.HMGet(key, fields...)
+	return c.cli.HMGet(ctx, key, fields...)
 }
 
 // HScan TODO
 func (c *client) HScan(ctx context.Context, key string, cursor uint64, match string, count int64) ScanResult {
-	return c.cli.HScan(key, cursor, match, count)
+	return c.cli.HScan(ctx, key, cursor, match, count)
 }
 
 // Scan TODO
 func (c *client) Scan(ctx context.Context, cursor uint64, match string, count int64) ScanResult {
-	return c.cli.Scan(cursor, match, count)
+	return c.cli.Scan(ctx, cursor, match, count)
 }
 
 // HSet TODO
 func (c *client) HSet(ctx context.Context, key string, values ...interface{}) IntResult {
-	return c.cli.HSet(key, values...)
+	return c.cli.HSet(ctx, key, values...)
 }
 
 // Incr TODO
 func (c *client) Incr(ctx context.Context, key string) IntResult {
-	return c.cli.Incr(key)
+	return c.cli.Incr(ctx, key)
 }
 
 // Keys TODO
 func (c *client) Keys(ctx context.Context, pattern string) StringSliceResult {
-	return c.cli.Keys(pattern)
+	return c.cli.Keys(ctx, pattern)
 }
 
 // LLen TODO
 func (c *client) LLen(ctx context.Context, key string) IntResult {
-	return c.cli.LLen(key)
+	return c.cli.LLen(ctx, key)
 }
 
 // LPush TODO
 func (c *client) LPush(ctx context.Context, key string, values ...interface{}) IntResult {
-	return c.cli.LPush(key, values...)
+	return c.cli.LPush(ctx, key, values...)
 }
 
 // LRange TODO
 func (c *client) LRange(ctx context.Context, key string, start, stop int64) StringSliceResult {
-	return c.cli.LRange(key, start, stop)
+	return c.cli.LRange(ctx, key, start, stop)
 }
 
 // LRem TODO
 func (c *client) LRem(ctx context.Context, key string, count int64, value interface{}) IntResult {
-	return c.cli.LRem(key, count, value)
+	return c.cli.LRem(ctx, key, count, value)
 }
 
 // LTrim TODO
 func (c *client) LTrim(ctx context.Context, key string, start, stop int64) StatusResult {
-	return c.cli.LTrim(key, start, stop)
+	return c.cli.LTrim(ctx, key, start, stop)
 }
 
 // MGet TODO
 func (c *client) MGet(ctx context.Context, keys ...string) SliceResult {
-	return c.cli.MGet(keys...)
+	return c.cli.MGet(ctx, keys...)
 }
 
 // MSet TODO
 func (c *client) MSet(ctx context.Context, values ...interface{}) StatusResult {
-	return c.cli.MSet(values...)
+	return c.cli.MSet(ctx, values...)
 }
 
 // Ping TODO
 func (c *client) Ping(ctx context.Context) StatusResult {
-	return c.cli.Ping()
+	return c.cli.Ping(ctx)
 }
 
 // Publish TODO
 func (c *client) Publish(ctx context.Context, channel string, message interface{}) IntResult {
-	return c.cli.Publish(channel, message)
+	return c.cli.Publish(ctx, channel, message)
 }
 
 // Rename TODO
 func (c *client) Rename(ctx context.Context, key, newkey string) StatusResult {
-	return c.cli.Rename(key, newkey)
+	return c.cli.Rename(ctx, key, newkey)
 }
 
 // RenameNX TODO
 func (c *client) RenameNX(ctx context.Context, key, newkey string) BoolResult {
-	return c.cli.RenameNX(key, newkey)
+	return c.cli.RenameNX(ctx, key, newkey)
 }
 
 // RPop TODO
 func (c *client) RPop(ctx context.Context, key string) StringResult {
-	return c.cli.RPop(key)
+	return c.cli.RPop(ctx, key)
 }
 
 // RPopLPush TODO
 func (c *client) RPopLPush(ctx context.Context, source, destination string) StringResult {
-	return c.cli.RPopLPush(source, destination)
+	return c.cli.RPopLPush(ctx, source, destination)
 }
 
 // RPush TODO
 func (c *client) RPush(ctx context.Context, key string, values ...interface{}) IntResult {
-	return c.cli.RPush(key, values...)
+	return c.cli.RPush(ctx, key, values...)
 }
 
 // SAdd TODO
 func (c *client) SAdd(ctx context.Context, key string, members ...interface{}) IntResult {
-	return c.cli.SAdd(key, members...)
+	return c.cli.SAdd(ctx, key, members...)
 }
 
 // Set TODO
 func (c *client) Set(ctx context.Context, key string, value interface{}, expiration time.Duration) StatusResult {
-	return c.cli.Set(key, value, expiration)
+	return c.cli.Set(ctx, key, value, expiration)
 }
 
 // SetNX TODO
 func (c *client) SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) BoolResult {
-	return c.cli.SetNX(key, value, expiration)
+	return c.cli.SetNX(ctx, key, value, expiration)
 }
 
 // TxPipeline TODO
@@ -257,30 +265,30 @@ func (c *client) Discard(ctx context.Context, pipe Pipeliner) error {
 
 // MSetNX TODO
 func (c *client) MSetNX(ctx context.Context, values ...interface{}) BoolResult {
-	return c.cli.MSetNX(values...)
+	return c.cli.MSetNX(ctx, values...)
 }
 
 // SMembers TODO
 func (c *client) SMembers(ctx context.Context, key string) StringSliceResult {
-	return c.cli.SMembers(key)
+	return c.cli.SMembers(ctx, key)
 }
 
 // SRem TODO
 func (c *client) SRem(ctx context.Context, key string, members ...interface{}) IntResult {
-	return c.cli.SRem(key, members...)
+	return c.cli.SRem(ctx, key, members...)
 }
 
 // TTL TODO
 func (c *client) TTL(ctx context.Context, key string) DurationResult {
-	return c.cli.TTL(key)
+	return c.cli.TTL(ctx, key)
 }
 
 // BLPop TODO
 func (c *client) BLPop(ctx context.Context, timeout time.Duration, keys ...string) StringSliceResult {
-	return c.cli.BLPop(timeout, keys...)
+	return c.cli.BLPop(ctx, timeout, keys...)
 }
 
 // ZRemRangeByRank TODO
-func (c *client) ZRemRangeByRank(key string, start, stop int64) IntResult {
-	return c.cli.ZRemRangeByRank(key, start, stop)
+func (c *client) ZRemRangeByRank(ctx context.Context, key string, start, stop int64) IntResult {
+	return c.cli.ZRemRangeByRank(ctx, key, start, stop)
 }

--- a/src/storage/dal/redis/commands.go
+++ b/src/storage/dal/redis/commands.go
@@ -65,5 +65,5 @@ type Commands interface {
 	TxPipeline(ctx context.Context) Pipeliner
 	Discard(ctx context.Context, pipe Pipeliner) error
 	BLPop(ctx context.Context, timeout time.Duration, keys ...string) StringSliceResult
-	ZRemRangeByRank(key string, start, stop int64) IntResult
+	ZRemRangeByRank(ctx context.Context, key string, start, stop int64) IntResult
 }

--- a/src/storage/dal/redis/example/example.go
+++ b/src/storage/dal/redis/example/example.go
@@ -19,7 +19,7 @@ import (
 
 	localRedis "configcenter/src/storage/dal/redis"
 
-	"github.com/go-redis/redis/v7"
+	"github.com/go-redis/redis/v8"
 )
 
 func main() {
@@ -40,7 +40,7 @@ func MyClient() {
 
 // MySentinelClient TODO
 func MySentinelClient() {
-	sentinelClient := localRedis.NewFailoverClient(&redis.FailoverOptions{
+	sentinelClient := localRedis.NewFailoverClusterClient(&redis.FailoverOptions{
 		MasterName:       "mymaster",
 		SentinelAddrs:    []string{"localhost:26379", "localhost:26380", "localhost:26381"},
 		SentinelPassword: "ss",
@@ -59,9 +59,9 @@ func DBOps(cli localRedis.Client) {
 	setKey := "mySetKey"
 
 	pipe := cli.Pipeline()
-	pipe.Set("aaa", 99, 0)
-	pipe.Get("aaa")
-	vals, err := pipe.Exec()
+	pipe.Set(context.Background(), "aaa", 99, 0)
+	pipe.Get(context.Background(), "aaa")
+	vals, err := pipe.Exec(context.Background())
 	checkErr(err)
 	fmt.Println("Pipeline", vals)
 
@@ -101,11 +101,11 @@ func DBOps(cli localRedis.Client) {
 		time.Sleep(time.Second)
 		cli.Publish(ctx, "channels", "hello,a subscribe test")
 	}()
-	msg, err := sub.ReceiveMessage()
+	msg, err := sub.ReceiveMessage(context.Background())
 	checkErr(err)
 	fmt.Println("ReceiveMessage:", msg)
 
-	err = sub.Unsubscribe("channels")
+	err = sub.Unsubscribe(context.Background(), "channels")
 	checkErr(err)
 
 	err = sub.Close()

--- a/src/storage/dal/redis/pipeline.go
+++ b/src/storage/dal/redis/pipeline.go
@@ -14,6 +14,7 @@ package redis
 
 import (
 	"context"
+
 	"github.com/go-redis/redis/v8"
 )
 

--- a/src/storage/dal/redis/pipeline.go
+++ b/src/storage/dal/redis/pipeline.go
@@ -13,7 +13,8 @@
 package redis
 
 import (
-	"github.com/go-redis/redis/v7"
+	"context"
+	"github.com/go-redis/redis/v8"
 )
 
 // Pipeliner is interface for redis pipeline technique
@@ -21,5 +22,5 @@ type Pipeliner interface {
 	redis.StatefulCmdable
 	Close() error
 	Discard() error
-	Exec() ([]redis.Cmder, error)
+	Exec(ctx context.Context) ([]redis.Cmder, error)
 }

--- a/src/storage/dal/redis/pubsub.go
+++ b/src/storage/dal/redis/pubsub.go
@@ -13,24 +13,25 @@
 package redis
 
 import (
+	"context"
 	"time"
 
-	"github.com/go-redis/redis/v7"
+	"github.com/go-redis/redis/v8"
 )
 
 // PubSub is the interface for redis Pub/Sub commands
 type PubSub interface {
-	Channel() <-chan *redis.Message
+	Channel(opts ...redis.ChannelOption) <-chan *redis.Message
 	ChannelSize(size int) <-chan *redis.Message
-	ChannelWithSubscriptions(size int) <-chan interface{}
+	ChannelWithSubscriptions(_ context.Context, size int) <-chan interface{}
 	Close() error
-	PSubscribe(patterns ...string) error
-	PUnsubscribe(patterns ...string) error
-	Ping(payload ...string) error
-	Receive() (interface{}, error)
-	ReceiveMessage() (*redis.Message, error)
-	ReceiveTimeout(timeout time.Duration) (interface{}, error)
+	PSubscribe(ctx context.Context, patterns ...string) error
+	PUnsubscribe(ctx context.Context, patterns ...string) error
+	Ping(ctx context.Context, payload ...string) error
+	Receive(ctx context.Context) (interface{}, error)
+	ReceiveMessage(ctx context.Context) (*redis.Message, error)
+	ReceiveTimeout(ctx context.Context, timeout time.Duration) (interface{}, error)
 	String() string
-	Subscribe(channels ...string) error
-	Unsubscribe(channels ...string) error
+	Subscribe(ctx context.Context, channels ...string) error
+	Unsubscribe(ctx context.Context, channels ...string) error
 }

--- a/src/storage/dal/redis/redis.go
+++ b/src/storage/dal/redis/redis.go
@@ -18,7 +18,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-redis/redis/v7"
+	"github.com/go-redis/redis/v8"
 )
 
 // Config define redis config
@@ -61,8 +61,9 @@ func NewFromConfig(cfg Config) (Client, error) {
 			DB:               dbNum,
 			PoolSize:         cfg.MaxOpenConns,
 			SentinelPassword: cfg.SentinelPassword,
+			RouteRandomly:    true,
 		}
-		client = NewFailoverClient(option)
+		client = NewFailoverClusterClient(option)
 	}
 
 	err = client.Ping(context.Background()).Err()

--- a/src/storage/dal/redis/test/commands_test.go
+++ b/src/storage/dal/redis/test/commands_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/go-redis/redis/v7"
+	"github.com/go-redis/redis/v8"
 )
 
 // these test cases extract from cases in following files at git commit bfb4c92
@@ -60,7 +60,7 @@ var _ = Describe("Commands", func() {
 		defer pubsub.Close()
 
 		{
-			msgi, err := pubsub.ReceiveTimeout(time.Second)
+			msgi, err := pubsub.ReceiveTimeout(context.Background(), time.Second)
 			Expect(err).NotTo(HaveOccurred())
 			subscr := msgi.(*redis.Subscription)
 			Expect(subscr.Kind).To(Equal("psubscribe"))
@@ -69,7 +69,7 @@ var _ = Describe("Commands", func() {
 		}
 
 		{
-			msgi, err := pubsub.ReceiveTimeout(time.Second)
+			msgi, err := pubsub.ReceiveTimeout(context.Background(), time.Second)
 			Expect(err.(net.Error).Timeout()).To(Equal(true))
 			Expect(msgi).To(BeNil())
 		}
@@ -78,10 +78,10 @@ var _ = Describe("Commands", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(n).To(Equal(int64(1)))
 
-		Expect(pubsub.PUnsubscribe("mychannel*")).NotTo(HaveOccurred())
+		Expect(pubsub.PUnsubscribe(context.Background(), "mychannel*")).NotTo(HaveOccurred())
 
 		{
-			msgi, err := pubsub.ReceiveTimeout(time.Second)
+			msgi, err := pubsub.ReceiveTimeout(context.Background(), time.Second)
 			Expect(err).NotTo(HaveOccurred())
 			subscr := msgi.(*redis.Message)
 			Expect(subscr.Channel).To(Equal("mychannel1"))
@@ -90,7 +90,7 @@ var _ = Describe("Commands", func() {
 		}
 
 		{
-			msgi, err := pubsub.ReceiveTimeout(time.Second)
+			msgi, err := pubsub.ReceiveTimeout(context.Background(), time.Second)
 			Expect(err).NotTo(HaveOccurred())
 			subscr := msgi.(*redis.Subscription)
 			Expect(subscr.Kind).To(Equal("punsubscribe"))
@@ -105,7 +105,7 @@ var _ = Describe("Commands", func() {
 		defer pubsub.Close()
 
 		{
-			msgi, err := pubsub.ReceiveTimeout(time.Second)
+			msgi, err := pubsub.ReceiveTimeout(context.Background(), time.Second)
 			Expect(err).NotTo(HaveOccurred())
 			subscr := msgi.(*redis.Subscription)
 			Expect(subscr.Kind).To(Equal("subscribe"))
@@ -114,7 +114,7 @@ var _ = Describe("Commands", func() {
 		}
 
 		{
-			msgi, err := pubsub.ReceiveTimeout(time.Second)
+			msgi, err := pubsub.ReceiveTimeout(context.Background(), time.Second)
 			Expect(err).NotTo(HaveOccurred())
 			subscr := msgi.(*redis.Subscription)
 			Expect(subscr.Kind).To(Equal("subscribe"))
@@ -123,7 +123,7 @@ var _ = Describe("Commands", func() {
 		}
 
 		{
-			msgi, err := pubsub.ReceiveTimeout(time.Second)
+			msgi, err := pubsub.ReceiveTimeout(context.Background(), time.Second)
 			Expect(err.(net.Error).Timeout()).To(Equal(true))
 			Expect(msgi).NotTo(HaveOccurred())
 		}
@@ -136,10 +136,10 @@ var _ = Describe("Commands", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(n).To(Equal(int64(1)))
 
-		Expect(pubsub.Unsubscribe("mychannel", "mychannel2")).NotTo(HaveOccurred())
+		Expect(pubsub.Unsubscribe(context.Background(), "mychannel", "mychannel2")).NotTo(HaveOccurred())
 
 		{
-			msgi, err := pubsub.ReceiveTimeout(time.Second)
+			msgi, err := pubsub.ReceiveTimeout(context.Background(), time.Second)
 			Expect(err).NotTo(HaveOccurred())
 			msg := msgi.(*redis.Message)
 			Expect(msg.Channel).To(Equal("mychannel"))
@@ -147,7 +147,7 @@ var _ = Describe("Commands", func() {
 		}
 
 		{
-			msgi, err := pubsub.ReceiveTimeout(time.Second)
+			msgi, err := pubsub.ReceiveTimeout(context.Background(), time.Second)
 			Expect(err).NotTo(HaveOccurred())
 			msg := msgi.(*redis.Message)
 			Expect(msg.Channel).To(Equal("mychannel2"))
@@ -155,7 +155,7 @@ var _ = Describe("Commands", func() {
 		}
 
 		{
-			msgi, err := pubsub.ReceiveTimeout(time.Second)
+			msgi, err := pubsub.ReceiveTimeout(context.Background(), time.Second)
 			Expect(err).NotTo(HaveOccurred())
 			subscr := msgi.(*redis.Subscription)
 			Expect(subscr.Kind).To(Equal("unsubscribe"))
@@ -164,7 +164,7 @@ var _ = Describe("Commands", func() {
 		}
 
 		{
-			msgi, err := pubsub.ReceiveTimeout(time.Second)
+			msgi, err := pubsub.ReceiveTimeout(context.Background(), time.Second)
 			Expect(err).NotTo(HaveOccurred())
 			subscr := msgi.(*redis.Subscription)
 			Expect(subscr.Kind).To(Equal("unsubscribe"))
@@ -175,10 +175,10 @@ var _ = Describe("Commands", func() {
 
 	It("should Pipeline", func() {
 		pipe := client.Pipeline()
-		ping := pipe.Ping()
-		set := pipe.Set("aaa", 99, 0)
-		get := pipe.Get("aaa")
-		_, err := pipe.Exec()
+		ping := pipe.Ping(context.Background())
+		set := pipe.Set(context.Background(), "aaa", 99, 0)
+		get := pipe.Get(context.Background(), "aaa")
+		_, err := pipe.Exec(context.Background())
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(ping.Err()).NotTo(HaveOccurred())

--- a/src/test/datacollection/benchmark/benchmark.go
+++ b/src/test/datacollection/benchmark/benchmark.go
@@ -22,7 +22,7 @@ import (
 
 	"configcenter/src/storage/dal/redis"
 
-	rawRedis "github.com/go-redis/redis/v7"
+	rawRedis "github.com/go-redis/redis/v8"
 	"github.com/spf13/cobra"
 )
 

--- a/src/tools/cmdb_ctl/cmd/snapshot.go
+++ b/src/tools/cmdb_ctl/cmd/snapshot.go
@@ -24,7 +24,7 @@ import (
 	ccRedis "configcenter/src/storage/dal/redis"
 	"configcenter/src/tools/cmdb_ctl/app/config"
 
-	rawRedis "github.com/go-redis/redis/v7"
+	rawRedis "github.com/go-redis/redis/v8"
 	"github.com/spf13/cobra"
 )
 
@@ -168,7 +168,7 @@ func (s *snapshotCheckService) checkHostSnapshot() error {
 	var receiveMsgErr error
 	go func() {
 		for len(stopChn) == 0 {
-			received, err := sub.ReceiveTimeout(time.Minute * 1)
+			received, err := sub.ReceiveTimeout(context.Background(), time.Minute*1)
 			if err != nil {
 				receiveMsgErr = fmt.Errorf("receive message from channel [%#v] in redis [%s] failed: %s", channelArr, redisConfig.Address, err.Error())
 				return


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- redis client支持读请求到从节点
### 修复的问题：
- xxxx

# 测试方案

## 一、环境准备

按照客户环境部署的Redis为一主二从三哨兵的模式，部署一套Redis的环境。

9000端口的redis为master节点，9001以及9002端口的redis为slave节点

![1](https://user-images.githubusercontent.com/66579465/210366745-a21a8848-8a9e-4345-abbd-4d02cc9b24d7.png)

![2](https://user-images.githubusercontent.com/66579465/210366758-e53b0d75-ffb0-4636-97fb-6103f4f0b45c.png)



## 二、测试过程

#### 1、编写测试小工具

使用go-redis三方库的v8版本中新加入的ClusterClient客户端的RouteRandomly参数，该参数可以将只读命令路由到随机主节点或从节点。

![3](https://user-images.githubusercontent.com/66579465/210366776-0d2a877c-f71c-4d43-ac65-f48e33a4c6b7.png)


#### 2、测试方式

在redis中创建1000个键值对，并使用上述客户端对这1000个键值对进行100000次set操作，100000次get操作，并通过redis的监控模式把监控日志记录起来。

![4](https://user-images.githubusercontent.com/66579465/210366791-6eb75392-a835-484c-aa9e-fc2db1b426cc.png)


工具运行结果：

![5](https://user-images.githubusercontent.com/66579465/210366802-51a48a90-8ddf-435e-954f-2c9e285071c4.png)



监控结果：

![6](https://user-images.githubusercontent.com/66579465/210366816-0507ae37-cd88-42d2-87c6-7f6cc8d5b339.png)


![7](https://user-images.githubusercontent.com/66579465/210366824-65dec089-3563-4e78-af93-33de90f6b699.png)


![8](https://user-images.githubusercontent.com/66579465/210366831-68e5aef8-5f3a-4215-bedc-7de2e1e553b8.png)


从工具运行结果以及监控结果中可以看出，测试的读请求的qps约为13000，并且通过RouteRandomly参数，读请求被趋于均分地分布在三个redis节点中。


