### PR TITLE
[bugfix] 修复导入模版的时候，非Default分组的字段数量超过1个，会导入失败的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ src/source_controller/*/coreservice
 src/web*/*server
 src/web*/cmdb_*
 *exvim*
-
+.idea
 .DS_Store
 .vscode
+scripts/cmdb_adminserver
+scripts/monstache
+pid
+vendor

--- a/src/scene_server/topo_server/logics/model/attribute.go
+++ b/src/scene_server/topo_server/logics/model/attribute.go
@@ -556,6 +556,7 @@ func (a *attribute) upsertObjectAttrBatch(kit *rest.Kit, objID string, attribute
 					continue
 				}
 				attr.PropertyGroup = grp.Data.GroupID
+				grpNameIDMap[attr.PropertyGroupName] = grp.Data.GroupID
 			}
 		} else {
 			attr.PropertyGroup = NewGroupID(true)

--- a/src/scene_server/topo_server/logics/model/attribute.go
+++ b/src/scene_server/topo_server/logics/model/attribute.go
@@ -522,6 +522,7 @@ func (a *attribute) upsertObjectAttrBatch(kit *rest.Kit, objID string, attribute
 
 	objRes := createObjectBatchObjResult{}
 	hasError := false
+	globalGroupIndex := int64(0)
 	for idx, attr := range attributes {
 		propID := attr.PropertyID
 		if propID == common.BKInstParentStr {
@@ -545,7 +546,7 @@ func (a *attribute) upsertObjectAttrBatch(kit *rest.Kit, objID string, attribute
 			} else {
 				grp := metadata.CreateModelAttributeGroup{
 					Data: metadata.Group{GroupName: attr.PropertyGroupName, GroupID: NewGroupID(false), ObjectID: objID,
-						OwnerID: kit.SupplierAccount, BizID: attr.BizID,
+						OwnerID: kit.SupplierAccount, BizID: attr.BizID, GroupIndex: globalGroupIndex,
 					}}
 
 				_, err := a.clientSet.CoreService().Model().CreateAttributeGroup(kit.Ctx, kit.Header, objID, grp)
@@ -557,6 +558,7 @@ func (a *attribute) upsertObjectAttrBatch(kit *rest.Kit, objID string, attribute
 				}
 				attr.PropertyGroup = grp.Data.GroupID
 				grpNameIDMap[attr.PropertyGroupName] = grp.Data.GroupID
+				globalGroupIndex++
 			}
 		} else {
 			attr.PropertyGroup = NewGroupID(true)


### PR DESCRIPTION
### 修复的问题：
- 新增资产模型后，使用Excel模板导入模型属性的时候，当非Default的分组内的属性数量大于1，会导入失败
