### PR TITLE
设置连接kafka允许的最小版本

### DIFF
--- a/src/scene_server/datacollection/app/server.go
+++ b/src/scene_server/datacollection/app/server.go
@@ -371,6 +371,7 @@ func (c *DataCollection) initModules() error {
 	// connect to snap kafka.
 	if c.config.SnapReportMode == "kafka" {
 		config := sarama.NewConfig()
+		config.Version = sarama.V0_10_2_0
 		config.Consumer.Return.Errors = false
 		config.Consumer.Offsets.AutoCommit.Enable = false // 禁用自动提交，改为手动
 		config.Consumer.Offsets.Initial = sarama.OffsetOldest


### PR DESCRIPTION
### 优化的功能:
- 设置连接kafka允许的最小版本，此版本为Shopify/sarama包允许的使用消费者组的最小版本，https://github.com/Shopify/sarama/issues/1363

