### PR TITLE
创建实例时枚举多选，枚举引用可以为空

### DIFF
--- a/src/source_controller/coreservice/core/instances/instance_validate.go
+++ b/src/source_controller/coreservice/core/instances/instance_validate.go
@@ -583,8 +583,11 @@ func (m *instanceManager) validInstIDs(kit *rest.Kit, property metadata.Attribut
 	}
 
 	if len(valIDs) == 0 {
-		blog.Errorf("enum quote inst id is null, rid: %s", kit.Rid)
-		return fmt.Errorf("enum quote inst id is null, please set the correct value")
+		if property.IsRequired {
+			blog.Errorf("enum quote inst id is null, rid: %s", kit.Rid)
+			return fmt.Errorf("enum quote inst id is null, please set the correct value")
+		}
+		return nil
 	}
 
 	if property.IsMultiple == nil {
@@ -595,7 +598,7 @@ func (m *instanceManager) validInstIDs(kit *rest.Kit, property metadata.Attribut
 		return kit.CCError.CCError(common.CCErrCommParamsNeedSingleChoice)
 	}
 
-	valEnumIDMap := make(map[int64]interface{}, 0)
+	valEnumIDMap := make(map[int64]struct{}, 0)
 	for _, valID := range valIDs {
 		valEnumID, err := util.GetInt64ByInterface(valID)
 		if err != nil {

--- a/src/source_controller/coreservice/core/instances/validator_util.go
+++ b/src/source_controller/coreservice/core/instances/validator_util.go
@@ -240,7 +240,7 @@ func FillLostedFieldValue(ctx context.Context, valData mapstr.MapStr, propertys 
 					break
 				}
 
-				defaultOptions := make([]string, 0)
+				defaultOptions := make([]interface{}, 0)
 				for _, k := range enumOptions {
 					if k.IsDefault {
 						defaultOptions = append(defaultOptions, k.ID)
@@ -264,7 +264,7 @@ func FillLostedFieldValue(ctx context.Context, valData mapstr.MapStr, propertys 
 					break
 				}
 
-				defaultOptions := make([]int64, 0)
+				defaultOptions := make([]interface{}, 0)
 				for _, k := range enumQuoteOptions {
 					defaultOptions = append(defaultOptions, k.InstID)
 				}


### PR DESCRIPTION
### 修复的问题：
- 在创建实例时，枚举多选，枚举引用为空时，无法保存实例数据
