### PR TITLE
动态分组中，枚举多选和枚举引用无法拉到选项值

### DIFF
--- a/src/ui/src/views/dynamic-group/form/form-property-list.vue
+++ b/src/ui/src/views/dynamic-group/form/form-property-list.vue
@@ -197,7 +197,7 @@
       },
       getNormalProps(property) {
         const type = property.bk_property_type
-        if (['list', 'enum'].includes(type)) {
+        if (['list', 'enum', 'enumquote', 'enummulti'].includes(type)) {
           return {
             options: property.option || []
           }


### PR DESCRIPTION
### 修复的问题：
- 动态分组中，枚举多选和枚举引用下拉框无法拉到选项值
