### PR TITLE
修复进程模版相关接口鉴权时，查不到服务模版导致的鉴权问题

### DIFF
--- a/src/source_controller/coreservice/core/process/service_template.go
+++ b/src/source_controller/coreservice/core/process/service_template.go
@@ -304,9 +304,13 @@ func (p *processOperation) UpdateServiceTemplate(kit *rest.Kit, templateID int64
 }
 
 // ListServiceTemplates TODO
-func (p *processOperation) ListServiceTemplates(kit *rest.Kit, option metadata.ListServiceTemplateOption) (*metadata.MultipleServiceTemplate, errors.CCErrorCoder) {
-	filter := map[string]interface{}{
-		common.BKAppIDField: option.BusinessID,
+func (p *processOperation) ListServiceTemplates(kit *rest.Kit, option metadata.ListServiceTemplateOption) (
+	*metadata.MultipleServiceTemplate, errors.CCErrorCoder) {
+
+	filter := map[string]interface{}{}
+	
+	if option.BusinessID != 0 {
+		filter[common.BKAppIDField] = option.BusinessID
 	}
 
 	// filter with matching any sub category


### PR DESCRIPTION
### 修复的问题：
- 修复进程模版相关接口鉴权时，查不到服务模版导致的鉴权问题，涉及到调用AuthorizeByServiceTemplateID方法查不到服务模版导致跳过鉴权的逻辑
