### PR TITLE
枚举多选，枚举引用无法创建动态分组

### DIFF
--- a/src/common/metadata/dynamic_grouping.go
+++ b/src/common/metadata/dynamic_grouping.go
@@ -170,10 +170,11 @@ const (
 
 func getAttributeType(attributeType string) (string, error) {
 	switch attributeType {
-	case common.FieldTypeSingleChar, common.FieldTypeLongChar, common.FieldTypeEnum, common.FieldTypeDate, common.FieldTypeTime,
-		common.FieldTypeTimeZone, common.FieldTypeUser, common.FieldTypeList:
+	case common.FieldTypeSingleChar, common.FieldTypeLongChar, common.FieldTypeEnum, common.FieldTypeDate,
+		common.FieldTypeEnumMulti, common.FieldTypeTime, common.FieldTypeTimeZone, common.FieldTypeUser,
+		common.FieldTypeList:
 		return stringType, nil
-	case common.FieldTypeInt, common.FieldTypeFloat, common.FieldTypeOrganization:
+	case common.FieldTypeInt, common.FieldTypeFloat, common.FieldTypeOrganization, common.FieldTypeEnumQuote:
 		return numericType, nil
 	case common.FieldTypeBool:
 		return boolType, nil

--- a/src/scene_server/topo_server/logics/inst/set.go
+++ b/src/scene_server/topo_server/logics/inst/set.go
@@ -94,7 +94,7 @@ func (s *set) getSetTemplate(kit *rest.Kit, data mapstr.MapStr, bizID int64) (me
 	st, err := s.clientSet.CoreService().SetTemplate().GetSetTemplate(kit.Ctx, kit.Header, bizID, setTemplateID)
 	if err != nil {
 		blog.Errorf("get set template failed, bizID: %d, setTemplateID: %d, err: %v, rid: %s", bizID,
-			setTemplateID, kit.Rid)
+			setTemplateID, err, kit.Rid)
 		return setTemplate, err
 	}
 


### PR DESCRIPTION
### 修复的问题：
- 创建动态分组时，枚举多选，枚举引用字段无法创建查询条件

issues #6654