### PR TITLE
helm dockerfile fix

### DIFF
--- a/helm/image/Dockerfile
+++ b/helm/image/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update && apt-get install -y nodejs
 RUN npm install gulp -g
 RUN npm install yarn -g
 
-# usage: docker build --build-arg user=release-v3.6.3 .
+# usage: docker build --build-arg user=release-v3.10.18 .
 
-ARG branch=release-v3.6.3
+ARG branch=release-v3.10.18
 RUN mkdir -p /data/src/ && cd /data/src/ && git clone -b ${branch} --single-branch https://github.com/Tencent/bk-cmdb.git 
 RUN apt-get install nodejs
 

--- a/helm/image/Dockerfile
+++ b/helm/image/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.13.0
+FROM golang:1.16.0
 RUN apt-get update
 RUN apt-get install -y git python jq curl
 
-RUN curl -sL https://deb.nodesource.com/setup_13.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN apt-get update && apt-get install -y nodejs
 RUN npm install gulp -g
 RUN npm install yarn -g
@@ -14,7 +14,7 @@ RUN mkdir -p /data/src/ && cd /data/src/ && git clone -b ${branch} --single-bran
 RUN apt-get install nodejs
 
 # make server
-RUN cd /data/src/ && ls -al ./ && mv bk-cmdb configcenter && cd /data/src/configcenter/src/ && export GOPATH=/data/ && make server
+RUN cd /data/src/ && ls -al ./ && mv bk-cmdb configcenter && cd /data/src/configcenter/src/ && export GOPATH=/data/ && export GO111MODULE=off && make server
 
 # generate configurations
 RUN cd /data/src/configcenter/src/bin/build/*/ && ls -al . &&     python init.py  \


### PR DESCRIPTION

### 修复的问题：
-  基于以前的golang版本已经无法正常编译，升级golang基础镜像，且不使用go mod
-  由于基础镜像升级，node13也无法安装，需要升级到node18 

本地已经做过构建测试。
