### PR TITLE
调整主机磁盘容量计算方式

### DIFF
--- a/src/scene_server/datacollection/collections/hostsnap/hostsnap.go
+++ b/src/scene_server/datacollection/collections/hostsnap/hostsnap.go
@@ -376,8 +376,9 @@ func parseSetter(val *gjson.Result, innerIP, outerIP string) (map[string]interfa
 	}
 	var disk uint64
 	for _, disktotal := range val.Get("data.disk.usage.#.total").Array() {
-		disk += disktotal.Uint() >> 10 >> 10 >> 10
+		disk += disktotal.Uint()
 	}
+	disk = disk >> 10 >> 10 >> 10
 	var mem = val.Get("data.mem.meminfo.total").Uint()
 	var hostname = val.Get("data.system.info.hostname").String()
 	hostname = strings.TrimSpace(hostname)


### PR DESCRIPTION
### 修复的问题：
- 调整主机磁盘容量的计算方式，将之前的每个分区容量转换为GB后取整再相加，调整为将所有分区容量相加后再转换为GB后取整

issues #6716