### PR TITLE
修复删除模型属性字段场景下错误的获取主机自动应用规则的问题

### DIFF
--- a/src/scene_server/topo_server/service/object_attribute.go
+++ b/src/scene_server/topo_server/service/object_attribute.go
@@ -221,7 +221,7 @@ func (s *Service) DeleteObjectAttribute(ctx *rest.Contexts) {
 	}
 
 	listRuleOption := metadata.ListHostApplyRuleOption{
-		ModuleIDs: []int64{id},
+		AttributeIDs: []int64{id},
 		Page: metadata.BasePage{
 			Limit: common.BKNoLimit,
 		},


### PR DESCRIPTION
### 修复的问题：
- 修复删除模型属性字段场景下错误的获取主机自动应用规则的问题
close #6752