### PR TITLE
修复当不传模块id时，查询不到业务下的服务实例的问题

### DIFF
--- a/src/scene_server/host_server/service/service_initfunc.go
+++ b/src/scene_server/host_server/service/service_initfunc.go
@@ -159,8 +159,7 @@ func (s *Service) initHostapplyrule(web *restful.WebService) {
 
 	utility.AddHandler(rest.Action{Verb: http.MethodGet,
 		Path: "/find/host_apply_rule/{host_apply_rule_id}/bk_biz_id/{bk_biz_id}/", Handler: s.GetHostApplyRule})
-	utility.AddHandler(rest.Action{Verb: http.MethodPost,
-		Path:    "/findmany/host_apply_rule/bk_biz_id/{bk_biz_id}",
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/findmany/host_apply_rule/bk_biz_id/{bk_biz_id}",
 		Handler: s.ListHostApplyRule})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost,
 		Path:    "/createmany/host_apply_rule/bk_biz_id/{bk_biz_id}/batch_create_or_update",
@@ -261,8 +260,8 @@ func (s *Service) initSpecial(web *restful.WebService) {
 	})
 
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/host/install/bk", Handler: s.BKSystemInstall})
-	utility.AddHandler(rest.Action{Verb: http.MethodPost,
-		Path: "/system/config/user_config/blueking_modify", Handler: s.FindSystemUserConfigBKSwitch})
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/system/config/user_config/blueking_modify",
+		Handler: s.FindSystemUserConfigBKSwitch})
 
 	utility.AddToRestfulWebService(web)
 

--- a/src/scene_server/proc_server/service/serviceinstance.go
+++ b/src/scene_server/proc_server/service/serviceinstance.go
@@ -468,11 +468,12 @@ func (ps *ProcServer) SearchServiceInstancesInModuleWeb(ctx *rest.Contexts) {
 	ctx.RespEntity(result)
 }
 
-// SearchServiceInstancesBySetTemplate TODO
+// SearchServiceInstancesBySetTemplate search service instances by set template
 func (ps *ProcServer) SearchServiceInstancesBySetTemplate(ctx *rest.Contexts) {
 	bizID, err := strconv.ParseInt(ctx.Request.PathParameter(common.BKAppIDField), 10, 64)
 	if err != nil {
-		blog.Errorf("SearchServiceInstancesBySetTemplate failed, parse bk_biz_id error, err: %s, rid: %s", err, ctx.Kit.Rid)
+		blog.Errorf("SearchServiceInstancesBySetTemplate failed, parse bk_biz_id error, err: %v, rid: %s", err,
+			ctx.Kit.Rid)
 		ctx.RespAutoError(ctx.Kit.CCError.CCErrorf(common.CCErrCommParamsIsInvalid, "bk_biz_id"))
 		return
 	}
@@ -506,9 +507,11 @@ func (ps *ProcServer) SearchServiceInstancesBySetTemplate(ctx *rest.Contexts) {
 		},
 		Condition: cond,
 	}
-	moduleInsts, err := ps.CoreAPI.CoreService().Instance().ReadInstance(ctx.Kit.Ctx, ctx.Kit.Header, common.BKInnerObjIDModule, qc)
+	moduleInsts, err := ps.CoreAPI.CoreService().Instance().ReadInstance(ctx.Kit.Ctx, ctx.Kit.Header,
+		common.BKInnerObjIDModule, qc)
 	if err != nil {
-		blog.Errorf("SearchServiceInstancesBySetTemplate failed, http request failed, err: %s, rid: %s", err.Error(), ctx.Kit.Rid)
+		blog.Errorf("SearchServiceInstancesBySetTemplate failed, http request failed, err: %v, rid: %s", err,
+			ctx.Kit.Rid)
 		ctx.RespAutoError(ctx.Kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed))
 		return
 	}
@@ -518,7 +521,8 @@ func (ps *ProcServer) SearchServiceInstancesBySetTemplate(ctx *rest.Contexts) {
 	for _, moduleInst := range moduleInsts.Info {
 		moduleID, err := util.GetInt64ByInterface(moduleInst[common.BKModuleIDField])
 		if err != nil {
-			blog.ErrorJSON("SearchServiceInstancesBySetTemplate failed, GetInt64ByInterface failed, moduleInst: %s, err: %#v, rid: %s", moduleInsts, err, ctx.Kit.Rid)
+			blog.ErrorJSON("SearchServiceInstancesBySetTemplate failed, GetInt64ByInterface failed, moduleInst: %s, "+
+				"err: %#v, rid: %s", moduleInsts, err, ctx.Kit.Rid)
 			ctx.RespAutoError(err)
 			return
 		}
@@ -533,10 +537,13 @@ func (ps *ProcServer) SearchServiceInstancesBySetTemplate(ctx *rest.Contexts) {
 		ModuleIDs:  modules,
 		Page:       input.Page,
 	}
-	serviceInstanceResult, err := ps.CoreAPI.CoreService().Process().ListServiceInstance(ctx.Kit.Ctx, ctx.Kit.Header, option)
+	serviceInstanceResult, err := ps.CoreAPI.CoreService().Process().ListServiceInstance(ctx.Kit.Ctx, ctx.Kit.Header,
+		option)
 	if err != nil {
-		blog.ErrorJSON("SearchServiceInstancesBySetTemplate failed, ListServiceInstance failed, filter: %s, err: %s, rid: %s", option, err, ctx.Kit.Rid)
-		ctx.RespWithError(err, common.CCErrProcGetServiceInstancesFailed, "get service instance in set_template_id: %d failed, err: %v", input.SetTemplateID, err)
+		blog.ErrorJSON("SearchServiceInstancesBySetTemplate failed, ListServiceInstance failed, filter: %s, err: %s,"+
+			" rid: %s", option, err, ctx.Kit.Rid)
+		ctx.RespWithError(err, common.CCErrProcGetServiceInstancesFailed, "get service instance in set_template_id: "+
+			"%d failed, err: %v", input.SetTemplateID, err)
 		return
 	}
 

--- a/src/scene_server/proc_server/service/serviceinstance.go
+++ b/src/scene_server/proc_server/service/serviceinstance.go
@@ -534,7 +534,7 @@ func (ps *ProcServer) SearchServiceInstancesBySetTemplate(ctx *rest.Contexts) {
 	ctx.RespEntity(serviceInstanceResult)
 }
 
-// SearchServiceInstancesInModule TODO
+// SearchServiceInstancesInModule search service instances in module
 func (ps *ProcServer) SearchServiceInstancesInModule(ctx *rest.Contexts) {
 	input := new(metadata.GetServiceInstanceInModuleInput)
 	if err := ctx.DecodeInto(input); err != nil {
@@ -555,15 +555,18 @@ func (ps *ProcServer) SearchServiceInstancesInModule(ctx *rest.Contexts) {
 
 	option := &metadata.ListServiceInstanceOption{
 		BusinessID: input.BizID,
-		ModuleIDs:  []int64{input.ModuleID},
 		Page:       input.Page,
 		SearchKey:  input.SearchKey,
 		Selectors:  input.Selectors,
 		HostIDs:    input.HostIDs,
 	}
+	if input.ModuleID != 0 {
+		option.ModuleIDs = []int64{input.ModuleID}
+	}
 	instances, err := ps.CoreAPI.CoreService().Process().ListServiceInstance(ctx.Kit.Ctx, ctx.Kit.Header, option)
 	if err != nil {
-		ctx.RespWithError(err, common.CCErrProcGetServiceInstancesFailed, "get service instance in module: %d failed, err: %v", input.ModuleID, err)
+		ctx.RespWithError(err, common.CCErrProcGetServiceInstancesFailed, "get service instance in module: %d failed"+
+			", err: %v", input.ModuleID, err)
 		return
 	}
 


### PR DESCRIPTION
### 修复的问题：
- 修复当不传模块id时，查询不到业务下的服务实例的问题, 对应接口文档：https://github.com/TencentBlueKing/bk-cmdb/blob/v3.10.x/docs/apidoc/cc/zh_hans/list_service_instance.md
