### PR TITLE
配置平台3.10.26.1-alpha6问题修复

### DIFF
--- a/src/ui/src/magicbox/magicbox.scss
+++ b/src/ui/src/magicbox/magicbox.scss
@@ -61,6 +61,7 @@
 .bk-dialog {
     .bk-dialog-header {
         .bk-dialog-header-inner {
+            line-height: 25px;
             white-space: normal;
         }
     }

--- a/src/ui/src/utils/tools.js
+++ b/src/ui/src/utils/tools.js
@@ -566,6 +566,12 @@ export function getPropertyCopyValue(originalValue, propertyType) {
       value = pair.join('\n')
       break
     }
+    case 'enum':
+      value =  propertyType.option.find(item => item.id === originalValue).name
+      break
+    case 'enummulti':
+      value = originalValue.map(value => propertyType.option.find(item => item.id === value).name).join('\n')
+      break
     default:
       value = originalValue
   }

--- a/src/ui/src/views/service-category/index.vue
+++ b/src/ui/src/views/service-category/index.vue
@@ -403,7 +403,6 @@
       handleDeleteCategory(id, type, index) {
         this.$bkInfo({
           title: this.$t('确认删除分类'),
-          zIndex: 999,
           confirmFn: async () => {
             await this.deleteServiceCategory({
               params: {

--- a/src/ui/src/views/service-template/index.vue
+++ b/src/ui/src/views/service-template/index.vue
@@ -443,6 +443,9 @@
         this.filter.mainClassification = ''
         this.filter.secondaryClassification = ''
         this.filter.templateName = ''
+        this.maincategoryId = 0
+        this.categoryId = null
+        this.secondaryList = []
         await this.getServiceClassification()
         await this.getTableData()
       }


### PR DESCRIPTION
### 修复的问题：
- 业务下服务分类dialog遮罩层未整屏覆盖
- 服务模板下清空筛选条件，表格中数据未实时更新
- dialog组件，标题中下划线符号未展示问题
- 主机表格中枚举，枚举多选字段复制字段值错误问题