### PR TITLE
当表格数字类型字段没传时，默认值和模型实例保持一致

### DIFF
--- a/src/source_controller/coreservice/service/model_quote/quoted_inst_validate.go
+++ b/src/source_controller/coreservice/service/model_quote/quoted_inst_validate.go
@@ -176,7 +176,7 @@ func getLostFieldDefaultValue(kit *rest.Kit, attr metadata.Attribute) interface{
 	case common.FieldTypeEnumMulti:
 		return make([]interface{}, 0)
 	case common.FieldTypeInt, common.FieldTypeFloat:
-		return 0
+		return nil
 	case common.FieldTypeBool:
 		return false
 	}


### PR DESCRIPTION
### 修复的问题：
- 当表格数字类型字段没传时，默认值和模型实例保持一致
