### PR TITLE
bug修复

### DIFF
--- a/src/ui/src/components/model-instance/property.vue
+++ b/src/ui/src/components/model-instance/property.vue
@@ -37,7 +37,7 @@
             </div>
             <template v-if="!loadingState.includes(property)">
               <template v-if="!readonly && !isPropertyEditable(property)">
-                <i class="is-related property-edit icon-cc-edit"
+                <i class="is-related property-edit icon-cc-edit-shape"
                   v-bk-tooltips="{
                     content: $t('系统限定不可修改'),
                     placement: 'top',
@@ -61,7 +61,7 @@
                     class="property-edit-btn"
                     :disabled="disabled"
                     @click="setEditState(property)">
-                    <i class="property-edit icon-cc-edit"></i>
+                    <i class="property-edit icon-cc-edit-shape"></i>
                   </bk-button>
                 </cmdb-auth>
                 <div class="property-form" v-if="property === editState.property">
@@ -94,7 +94,7 @@
                 && property !== editState.property">
                 <div class="copy-box">
                   <i
-                    class="property-copy icon-cc-details-copy"
+                    class="property-copy icon-cc-copy"
                     @click="handleCopy(property.bk_property_id)">
                   </i>
                   <transition name="fade">

--- a/src/ui/src/components/model-manage/field-group/index.vue
+++ b/src/ui/src/components/model-manage/field-group/index.vue
@@ -22,13 +22,13 @@
     <div class="field-options">
       <cmdb-auth v-if="isShowOptionBtn" :auth="authResources" @update-auth="handleReceiveAuth">
         <template #default="{ disabled }">
-          <bk-button theme="primary" :disabled="disabled"
+          <bk-button theme="primary" :disabled="disabled || activeModel.bk_ispaused"
             @click="handleAddField(displayGroupedProperties[0])">{{$t('新建字段')}}</bk-button>
         </template>
       </cmdb-auth>
       <cmdb-auth v-if="isShowOptionBtn" :auth="authResources" @update-auth="handleReceiveAuth">
         <template #default="{ disabled }">
-          <bk-button :disabled="disabled" @click="handleAddGroup">{{$t('新建分组')}}</bk-button>
+          <bk-button :disabled="disabled || activeModel.bk_ispaused" @click="handleAddGroup">{{$t('新建分组')}}</bk-button>
         </template>
       </cmdb-auth>
       <bk-button @click="previewShow = true" :disabled="!properties.length">{{

--- a/src/ui/src/views/model-manage/children/model-import-export/model-export-pane/model-export-setting.vue
+++ b/src/ui/src/views/model-manage/children/model-import-export/model-export-pane/model-export-setting.vue
@@ -24,11 +24,11 @@
         </bk-radio-group>
       </bk-form-item>
       <template v-if="isEncrypt">
-        <bk-form-item :label="t('密码设置')" required property="password">
+        <bk-form-item :label="t('密码设置')" required property="password" icon-offset="-20">
           <bk-input class="setting-form-input"
             v-model="settingForm.password" type="password" :placeholder="t('长度 6-20 个字符，必须包含英文字母、数字和特殊符号')"></bk-input>
         </bk-form-item>
-        <bk-form-item :label="t('二次确认')" required property="confirmedPassword">
+        <bk-form-item :label="t('二次确认')" required property="confirmedPassword" icon-offset="-20">
           <bk-input class="setting-form-input" v-model="settingForm.confirmedPassword" type="password"
             :placeholder="t('请输入同样的密码，以确认密码准确')"></bk-input>
         </bk-form-item>

--- a/src/ui/src/views/model-manage/index.vue
+++ b/src/ui/src/views/model-manage/index.vue
@@ -121,7 +121,10 @@
             :clearable="true"
             :right-icon="'bk-icon icon-search'"
             :placeholder="$t('请输入关键字')"
-            v-model.trim="modelSearchKey"
+            :value="modelSearchKey"
+            @change="inputChange"
+            @compositionstart.native="inputCompositionStart"
+            @compositionend.native="inputCompositionEnd"
           >
           </bk-input>
         </div>
@@ -456,6 +459,7 @@
         modelStatisticsSet: {}, // 模型实例数量统计
         curCreateModel: {}, // 当前创建的模型
         modelCreatedDialogVisible: false,
+        otherInputVal: '', // 针对某些输入法中文输入失焦后自动清空输入框情况 如：搜狗输入法
 
         // 分组表单弹窗
         groupDialog: {
@@ -681,6 +685,26 @@
         'deleteClassification',
       ]),
       ...mapActions('objectModel', ['createObject', 'updateObject']),
+      inputChange(val) {
+        // 在输入过程中如果是中文输入法 不让modelSearchKey变化
+        if (this.isComposition) {
+          this.modelSearchKey = this.otherInputVal
+          return
+        }
+        this.modelSearchKey = val
+      },
+      inputCompositionStart() {
+        // 当前为中文输入法
+        this.isComposition = true
+        this.otherInputVal = this.modelSearchKey
+      },
+      inputCompositionEnd(event) {
+        // 兼容输入框输入中文突然变英文的情况
+        setTimeout(() => {
+          this.isComposition = false
+          this.modelSearchKey = event.target.value
+        }, 100)
+      },
       loadAllModels() {
         return this.searchClassificationsObjects({
           params: {},

--- a/src/ui/src/views/resource-manage/index.vue
+++ b/src/ui/src/views/resource-manage/index.vue
@@ -119,7 +119,8 @@
     methods: {
       filterModel() {
         if (this.filter) {
-          const models = this.models.filter(model => model.bk_obj_name.indexOf(this.filter) > -1)
+          const models = this.models.filter(model => model.bk_obj_name.toLocaleLowerCase()
+            .indexOf(this.filter.toLocaleLowerCase()) > -1)
           this.matchedModels = models.map(model => model.bk_obj_id)
         } else {
           this.matchedModels = null


### PR DESCRIPTION
### 修复的问题：
- 某些输入法中文输入时候，失焦时候会自动清空输入框导致进入详情页错误
- 模型停用后，新建字段按钮没有置灰，仍可以新建分组
- 导出模型，文件加密二次确认提示icon样式与密码框小眼睛样式重合
- 资源目录搜索支持大小写
- 实例信息详情 编辑和复制图标更新
