### PR TITLE
字段模版先更新唯一校验再创建唯一校验

### DIFF
--- a/src/scene_server/topo_server/service/field_template/field_template.go
+++ b/src/scene_server/topo_server/service/field_template/field_template.go
@@ -765,24 +765,6 @@ func (s *service) updateFieldTmplUnique(kit *rest.Kit, templateID int64, propert
 
 	auditLogs := make([]metadata.AuditLog, 0)
 	audit := auditlog.NewFieldTmplAuditLog(s.clientSet.CoreService())
-	if len(createUniques) != 0 {
-		resp, ccErr := s.clientSet.CoreService().FieldTemplate().CreateFieldTemplateUniques(kit.Ctx, kit.Header,
-			templateID, createUniques)
-		if ccErr != nil {
-			blog.Errorf("create field template uniques failed, data: %v, err: %v, rid: %s", createUniques, ccErr,
-				kit.Rid)
-			return ccErr
-		}
-
-		generateAuditParameter := auditlog.NewGenerateAuditCommonParameter(kit, metadata.AuditCreate)
-		createLogs, err := audit.GenerateFieldTmplUniqueAuditLog(generateAuditParameter, resp.IDs, nil)
-		if err != nil {
-			blog.Errorf("generate field template unique audit log failed, err: %v, rid: %s", err, kit.Rid)
-			return err
-		}
-		auditLogs = append(auditLogs, createLogs...)
-	}
-
 	if len(updateUniques) != 0 {
 		ccErr := s.clientSet.CoreService().FieldTemplate().UpdateFieldTemplateUniques(kit.Ctx, kit.Header, templateID,
 			updateUniques)
@@ -799,6 +781,24 @@ func (s *service) updateFieldTmplUnique(kit *rest.Kit, templateID int64, propert
 			return err
 		}
 		auditLogs = append(auditLogs, updateLogs...)
+	}
+
+	if len(createUniques) != 0 {
+		resp, ccErr := s.clientSet.CoreService().FieldTemplate().CreateFieldTemplateUniques(kit.Ctx, kit.Header,
+			templateID, createUniques)
+		if ccErr != nil {
+			blog.Errorf("create field template uniques failed, data: %v, err: %v, rid: %s", createUniques, ccErr,
+				kit.Rid)
+			return ccErr
+		}
+
+		generateAuditParameter := auditlog.NewGenerateAuditCommonParameter(kit, metadata.AuditCreate)
+		createLogs, err := audit.GenerateFieldTmplUniqueAuditLog(generateAuditParameter, resp.IDs, nil)
+		if err != nil {
+			blog.Errorf("generate field template unique audit log failed, err: %v, rid: %s", err, kit.Rid)
+			return err
+		}
+		auditLogs = append(auditLogs, createLogs...)
 	}
 
 	if len(auditLogs) == 0 {

--- a/src/scene_server/topo_server/service/field_template/object_relation.go
+++ b/src/scene_server/topo_server/service/field_template/object_relation.go
@@ -546,20 +546,7 @@ func (s *service) doSyncFieldTemplateTask(kit *rest.Kit, option *metadata.SyncOb
 			return err
 		}
 
-		// 4、create a unique check for the model
-		if len(create) > 0 {
-			for _, unique := range create {
-				op := metadata.CreateModelAttrUnique{Data: unique, FromTemplate: true}
-				_, err := s.clientSet.CoreService().Model().CreateModelAttrUnique(kit.Ctx, kit.Header, objectID, op)
-				if err != nil {
-					blog.Errorf("create unique failed for failed: raw: %#v, err: %v, rid: %s", unique, err, kit.Rid)
-					return err
-				}
-			}
-			return nil
-		}
-
-		// 5、update the unique validation of the model
+		// 4、update the unique validation of the model
 		if len(update) > 0 {
 			for _, unique := range update {
 				input := metadata.UpdateUniqueRequest{
@@ -576,6 +563,20 @@ func (s *service) doSyncFieldTemplateTask(kit *rest.Kit, option *metadata.SyncOb
 				}
 			}
 		}
+
+		// 5、create a unique check for the model
+		if len(create) > 0 {
+			for _, unique := range create {
+				op := metadata.CreateModelAttrUnique{Data: unique, FromTemplate: true}
+				_, err := s.clientSet.CoreService().Model().CreateModelAttrUnique(kit.Ctx, kit.Header, objectID, op)
+				if err != nil {
+					blog.Errorf("create unique failed for failed: raw: %#v, err: %v, rid: %s", unique, err, kit.Rid)
+					return err
+				}
+			}
+			return nil
+		}
+
 		return nil
 	})
 


### PR DESCRIPTION
### 优化的功能:
- 字段模版先更新唯一校验再创建唯一校验，防止旧唯一校验和新加唯一校验规则冲突
