### PR TITLE
修复字段组合模版两个属性id和name一样时对比报错问题

### DIFF
--- a/src/scene_server/topo_server/logics/field_template/compare_attr.go
+++ b/src/scene_server/topo_server/logics/field_template/compare_attr.go
@@ -160,7 +160,7 @@ func (c *comparator) preCheckAttr(kit *rest.Kit, objID string, attrs []metadata.
 			return nil, kit.CCError.CCErrorf(common.CCErrCommParamsIsInvalid, "attributes")
 		}
 
-		if _, exists := params.tmplPropIDMap[attr.PropertyName]; exists {
+		if _, exists := params.tmplNameMap[attr.PropertyName]; exists {
 			blog.Errorf("template attribute name(%s) duplicate, rid: %s", attr.PropertyName, kit.Rid)
 			return nil, kit.CCError.CCErrorf(common.CCErrCommParamsIsInvalid, "attributes")
 		}


### PR DESCRIPTION
### 修复的问题：
- 修复字段组合模版两个属性id和name一样时对比报错问题
