### PR TITLE
迁移3.11.x分支中的修复的问题

### DIFF
--- a/src/common/index/compare.go
+++ b/src/common/index/compare.go
@@ -15,6 +15,7 @@ package index
 import (
 	"reflect"
 
+	"configcenter/src/common/util"
 	"configcenter/src/storage/dal/types"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -75,7 +76,18 @@ func IndexEqual(toDBIndex, dbIndex types.Index) bool {
 		if !exists {
 			return false
 		}
-		if val != dbVal {
+
+		valInt, err := util.GetIntByInterface(val)
+		if err != nil {
+			return false
+		}
+
+		dbValInt, err := util.GetIntByInterface(dbVal)
+		if err != nil {
+			return false
+		}
+
+		if valInt != dbValInt {
 			return false
 		}
 	}

--- a/src/scene_server/admin_server/upgrader/history/x18.10.30.01/association.go
+++ b/src/scene_server/admin_server/upgrader/history/x18.10.30.01/association.go
@@ -70,7 +70,7 @@ func createInstanceAssociationIndex(ctx context.Context, db dal.RDB, conf *upgra
 		if exist {
 			continue
 		}
-		if err := db.Table(common.BKTableNameInstAsst).CreateIndex(ctx, idx); err != nil {
+		if err := db.Table(common.BKTableNameInstAsst).CreateIndex(ctx, idx); err != nil && !db.IsDuplicatedError(err) {
 			blog.ErrorJSON("create index to cc_InstAsst error, err:%s, current index:%s, all create index:%s", err.Error(), idx, createIdxArr)
 			return err
 		}

--- a/src/scene_server/admin_server/upgrader/history/x18.12.12.05/remove_deleted_inst_asst.go
+++ b/src/scene_server/admin_server/upgrader/history/x18.12.12.05/remove_deleted_inst_asst.go
@@ -303,7 +303,7 @@ func createInstanceAssociationIndex(ctx context.Context, db dal.RDB, conf *upgra
 		if exist {
 			continue
 		}
-		if err := db.Table(bkTableNameInstAsst).CreateIndex(ctx, idx); err != nil {
+		if err := db.Table(bkTableNameInstAsst).CreateIndex(ctx, idx); err != nil && !db.IsDuplicatedError(err) {
 			blog.ErrorJSON("create index to cc_InstAsst error, err:%s, current index:%s, all create index:%s", err.Error(), idx, createIdxArr)
 			return err
 		}

--- a/src/scene_server/admin_server/upgrader/history/x19.09.03.05/create_inst_name_index.go
+++ b/src/scene_server/admin_server/upgrader/history/x19.09.03.05/create_inst_name_index.go
@@ -36,7 +36,7 @@ func CreateInstNameIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config)
 		Background: false,
 	}
 
-	if err := db.Table(common.BKTableNameBaseInst).CreateIndex(ctx, idx); err != nil {
+	if err := db.Table(common.BKTableNameBaseInst).CreateIndex(ctx, idx); err != nil && !db.IsDuplicatedError(err) {
 		blog.Errorf("CreateIndex failed, err: %+v", err)
 		return fmt.Errorf("CreateIndex failed, err: %v", err)
 	}

--- a/src/scene_server/admin_server/upgrader/history/x19.09.03.05/create_object_id_index.go
+++ b/src/scene_server/admin_server/upgrader/history/x19.09.03.05/create_object_id_index.go
@@ -36,7 +36,7 @@ func CreateObjectIDIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config)
 		Background: false,
 	}
 
-	if err := db.Table(common.BKTableNameObjUnique).CreateIndex(ctx, idx); err != nil {
+	if err := db.Table(common.BKTableNameObjUnique).CreateIndex(ctx, idx); err != nil && !db.IsDuplicatedError(err) {
 		blog.Errorf("CreateObjectIDIndex failed, err: %+v", err)
 		return fmt.Errorf("CreateObjectIDIndex failed, err: %v", err)
 	}

--- a/src/scene_server/admin_server/upgrader/history/x19.10.22.02/add_host_index.go
+++ b/src/scene_server/admin_server/upgrader/history/x19.10.22.02/add_host_index.go
@@ -57,7 +57,7 @@ func addHostIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config) error 
 		Background: false,
 	}
 
-	if err := db.Table(common.BKTableNameBaseHost).CreateIndex(ctx, idx); err != nil {
+	if err := db.Table(common.BKTableNameBaseHost).CreateIndex(ctx, idx); err != nil && !db.IsDuplicatedError(err) {
 		blog.Errorf("CreateIndex failed, err: %+v", err)
 		return fmt.Errorf("CreateIndex failed, err: %v", err)
 	}

--- a/src/scene_server/admin_server/upgrader/history/y3.6.201909062359/create_table.go
+++ b/src/scene_server/admin_server/upgrader/history/y3.6.201909062359/create_table.go
@@ -65,7 +65,8 @@ func createSetTemplateTables(ctx context.Context, db dal.RDB, conf *upgrader.Con
 			Unique:     true,
 			Background: true,
 		}
-		if err := db.Table(common.BKTableNameSetTemplate).CreateIndex(ctx, index); err != nil {
+		err = db.Table(common.BKTableNameSetTemplate).CreateIndex(ctx, index)
+		if err != nil && !db.IsDuplicatedError(err) {
 			blog.ErrorJSON("add index for table: %s failed, index: %s, err:%s", common.BKTableNameSetTemplate, index, err.Error())
 			return err
 		}

--- a/src/scene_server/admin_server/upgrader/history/y3.6.201910091234/settemplate_sync_status.go
+++ b/src/scene_server/admin_server/upgrader/history/y3.6.201910091234/settemplate_sync_status.go
@@ -86,7 +86,7 @@ func SetTemplateSyncStatusMigrate(ctx context.Context, db dal.RDB, conf *upgrade
 				continue
 			}
 			err := db.Table(tableName).CreateIndex(ctx, index)
-			if err != nil {
+			if err != nil && !db.IsDuplicatedError(err) {
 				blog.ErrorJSON("add index %s for table %s failed, err:%s", index, tableName, err.Error())
 				return err
 			}

--- a/src/scene_server/admin_server/upgrader/history/y3.7.201911141719/init_host_property_apply.go
+++ b/src/scene_server/admin_server/upgrader/history/y3.7.201911141719/init_host_property_apply.go
@@ -144,7 +144,8 @@ func InitHostPropertyApplyDataModel(ctx context.Context, db dal.RDB, conf *upgra
 		},
 	}
 	for _, index := range indexes {
-		if err := db.Table(common.BKTableNameHostApplyRule).CreateIndex(ctx, index); err != nil {
+		err = db.Table(common.BKTableNameHostApplyRule).CreateIndex(ctx, index)
+		if err != nil && !db.IsDuplicatedError(err) {
 			blog.Errorf("InitHostPropertyApplyDataModel failed, add index failed, table: %s, index: %+v, err: %s", common.BKTableNameHostApplyRule, index, err.Error())
 			return fmt.Errorf("add index failed, table: %s, index: %s, err: %s", common.BKTableNameHostApplyRule, index.Name, err.Error())
 		}

--- a/src/scene_server/admin_server/upgrader/history/y3.8.202001172032/create_audit_log_table.go
+++ b/src/scene_server/admin_server/upgrader/history/y3.8.202001172032/create_audit_log_table.go
@@ -62,7 +62,7 @@ func addAuditLogTableIndex(ctx context.Context, db dal.RDB, conf *upgrader.Confi
 		if exist {
 			continue
 		}
-		if err := db.Table(common.BKTableNameAuditLog).CreateIndex(ctx, idx); err != nil {
+		if err := db.Table(common.BKTableNameAuditLog).CreateIndex(ctx, idx); err != nil && !db.IsDuplicatedError(err) {
 			blog.ErrorJSON("create index to BKTableNameAuditLog error, err:%s, current index:%s, all create index:%s", err.Error(), idx, createIdxArr)
 			return err
 		}

--- a/src/scene_server/admin_server/upgrader/history/y3.8.202006021120/add_service_instance_index.go
+++ b/src/scene_server/admin_server/upgrader/history/y3.8.202006021120/add_service_instance_index.go
@@ -49,7 +49,7 @@ func addServiceInstanceIndex(ctx context.Context, db dal.RDB, conf *upgrader.Con
 	}
 
 	err = db.Table(tableName).CreateIndex(ctx, index)
-	if err != nil {
+	if err != nil && !db.IsDuplicatedError(err) {
 		blog.ErrorJSON("add index %s for table %s failed, err:%s", index, tableName, err)
 		return err
 	}

--- a/src/scene_server/admin_server/upgrader/y3.10.202109181134/migrate_svc_inst_id_to_proc.go
+++ b/src/scene_server/admin_server/upgrader/y3.10.202109181134/migrate_svc_inst_id_to_proc.go
@@ -217,7 +217,8 @@ func addProcUniqueIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config) 
 		if _, exists := existIndexMap[index.Name]; exists {
 			continue
 		}
-		if err := db.Table(common.BKTableNameBaseProcess).CreateIndex(ctx, index); err != nil {
+		err = db.Table(common.BKTableNameBaseProcess).CreateIndex(ctx, index)
+		if err != nil && !db.IsDuplicatedError(err) {
 			blog.Errorf("add process unique index(%#v) failed, err: %+v", index, err)
 			return err
 		}

--- a/src/scene_server/admin_server/upgrader/y3.9.202002131522/add_cloud_host_index.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202002131522/add_cloud_host_index.go
@@ -49,7 +49,7 @@ func addCloudHostIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config) e
 	}
 
 	err = db.Table(tableName).CreateIndex(ctx, index)
-	if err != nil {
+	if err != nil && !db.IsDuplicatedError(err) {
 		blog.ErrorJSON("add index %s for table %s failed, err:%s", index, tableName, err)
 		return err
 	}

--- a/src/scene_server/admin_server/upgrader/y3.9.202002131522/add_plat_index.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202002131522/add_plat_index.go
@@ -49,7 +49,7 @@ func addPlatIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config) error 
 	}
 
 	err = db.Table(tableName).CreateIndex(ctx, index)
-	if err != nil {
+	if err != nil && !db.IsDuplicatedError(err) {
 		blog.ErrorJSON("add index %s for table %s failed, err:%s", index, tableName, err)
 		return err
 	}

--- a/src/scene_server/admin_server/upgrader/y3.9.202010151650/add_cloudid_index.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202010151650/add_cloudid_index.go
@@ -40,7 +40,7 @@ func addCloudIDIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config) err
 
 	for _, tableName := range tableNames {
 		err := db.Table(tableName).CreateIndex(ctx, index)
-		if err != nil {
+		if err != nil && !db.IsDuplicatedError(err) {
 			blog.ErrorJSON("add index %s for table %s failed, err:%s", index, tableName, err)
 			return err
 		}

--- a/src/scene_server/admin_server/upgrader/y3.9.202010211805/add_host_lock_table.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202010211805/add_host_lock_table.go
@@ -50,7 +50,7 @@ func addIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
 	}
 
 	err := db.Table(common.BKTableNameHostLock).CreateIndex(ctx, index)
-	if err != nil {
+	if err != nil && !db.IsDuplicatedError(err) {
 		blog.ErrorJSON("add index %s for table %s failed, err:%s", index, common.BKTableNameHostLock, err)
 		return err
 	}

--- a/src/scene_server/admin_server/upgrader/y3.9.202011192014/change_unique_index.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202011192014/change_unique_index.go
@@ -73,7 +73,8 @@ func changeUniqueIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config) (
 					tableName, idxUniqueGroupName, err.Error())
 				return err
 			}
-			if err := db.Table(tableName).CreateIndex(ctx, idxUniqueObjIDGroupName); err != nil {
+			err = db.Table(tableName).CreateIndex(ctx, idxUniqueObjIDGroupName)
+			if err != nil && !db.IsDuplicatedError(err) {
 				blog.ErrorJSON("create table(%s) index error. idx name: %s, index: %s, err: %s",
 					tableName, idxUniqueGroupName, idxUniqueObjIDGroupName, err.Error())
 				return err

--- a/src/scene_server/admin_server/upgrader/y3.9.202101061721/add_del_archive_index.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202101061721/add_del_archive_index.go
@@ -93,13 +93,13 @@ func addDelArchiveIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config) 
 	}
 
 	err = db.Table(common.BKTableNameDelArchive).CreateIndex(ctx, oidCollIndex)
-	if err != nil {
+	if err != nil && !db.IsDuplicatedError(err) {
 		blog.ErrorJSON("add index %s for del archive table failed, err: %s", oidCollIndex, err)
 		return err
 	}
 
 	err = db.Table(common.BKTableNameDelArchive).CreateIndex(ctx, collIndex)
-	if err != nil {
+	if err != nil && !db.IsDuplicatedError(err) {
 		blog.ErrorJSON("add index %s for del archive table failed, err: %s", collIndex, err)
 		return err
 	}

--- a/src/scene_server/admin_server/upgrader/y3.9.202102011055/add_os_type_index.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202102011055/add_os_type_index.go
@@ -33,7 +33,7 @@ func addOsTypeIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config) erro
 	}
 
 	err := db.Table(common.BKTableNameBaseHost).CreateIndex(ctx, index)
-	if err != nil {
+	if err != nil && !db.IsDuplicatedError(err) {
 		blog.ErrorJSON("add index %s for table %s failed, err:%s", index, common.BKTableNameBaseHost, err)
 		return err
 	}

--- a/src/scene_server/admin_server/upgrader/y3.9.202102261105/add_instass_proc_index.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202102261105/add_instass_proc_index.go
@@ -38,7 +38,7 @@ func addInstassProcIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config)
 	}
 
 	err := db.Table(common.BKTableNameInstAsst).CreateIndex(ctx, index)
-	if err != nil {
+	if err != nil && !db.IsDuplicatedError(err) {
 		blog.ErrorJSON("add index %s for table %s failed, err:%s", index, common.BKTableNameInstAsst, err)
 		return err
 	}
@@ -54,7 +54,7 @@ func addInstassProcIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config)
 	}
 
 	err = db.Table(common.BKTableNameProcessTemplate).CreateIndex(ctx, index)
-	if err != nil {
+	if err != nil && !db.IsDuplicatedError(err) {
 		blog.ErrorJSON("add index %s for table %s failed, err:%s", index, common.BKTableNameProcessTemplate, err)
 		return err
 	}

--- a/src/scene_server/admin_server/upgrader/y3.9.202104211151/change_set_unique_index.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202104211151/change_set_unique_index.go
@@ -81,7 +81,8 @@ func changeSetUniqueIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config
 		}
 	}
 	if isCreateUniqueSetName {
-		if err := db.Table(tableName).CreateIndex(ctx, idxUniqueParentIDSetName); err != nil {
+		err = db.Table(tableName).CreateIndex(ctx, idxUniqueParentIDSetName)
+		if err != nil && !db.IsDuplicatedError(err) {
 			blog.ErrorJSON("create table(%s) index error. idx name: %s, index: %s, err: %s",
 				tableName, idxUniqueParentIDSetName.Name, idxUniqueParentIDSetName, err.Error())
 			if db.IsDuplicatedError(err) {

--- a/src/scene_server/admin_server/upgrader/y3.9.202106291420/index.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202106291420/index.go
@@ -15,9 +15,9 @@ package y3_9_202106291420
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"configcenter/src/common/blog"
+	"configcenter/src/common/index"
 	"configcenter/src/scene_server/admin_server/upgrader"
 	"configcenter/src/storage/dal"
 	"configcenter/src/storage/dal/types"
@@ -25,7 +25,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-func addIndexex(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error) {
+func addIndexes(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error) {
 
 	indexes := map[string]types.Index{
 		"cc_ServiceInstance": {
@@ -41,32 +41,32 @@ func addIndexex(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err err
 		},
 	}
 
-	for tableName, index := range indexes {
-
+	for tableName, idx := range indexes {
 		dbIndexes, err := db.Table(tableName).Indexes(ctx)
 		if err != nil {
 			blog.ErrorJSON("find collection(%s) index error. err: %s", tableName, err.Error())
 			return err
 		}
+
 		indexExist := false
 		for _, dbIndex := range dbIndexes {
-			if dbIndex.Name == index.Name {
-				blog.InfoJSON("start  collection(%s) equal db index(%s) logic index(%s)", tableName, dbIndex, index)
-				if reflect.DeepEqual(dbIndex.Keys, index.Keys) {
-					indexExist = true
-					continue
-				} else {
-					err := fmt.Errorf("collection(%s) index(%s) has exists, but keys not equal", tableName, index.Name)
-					blog.ErrorJSON("%s, db index: %s, logic index: %s", err.Error(), dbIndex, index)
-					return err
+			if dbIndex.Name == idx.Name {
+				if !index.IndexEqual(idx, dbIndex) {
+					blog.Errorf("index keys are not equal, db index: %+v, logic index: %+v", err, dbIndex, idx)
+					return fmt.Errorf("collection(%s) index(%s) exists, but keys not equal", tableName, idx.Name)
 				}
+				indexExist = true
+				break
 			}
 		}
-		if !indexExist {
-			if err := db.Table(tableName).CreateIndex(ctx, index); err != nil {
-				blog.ErrorJSON("collection(%s)  create index(%s) error. index: %s, err: %s", tableName, index.Name, index, err.Error())
-				return err
-			}
+
+		if indexExist {
+			continue
+		}
+
+		if err = db.Table(tableName).CreateIndex(ctx, idx); err != nil && !db.IsDuplicatedError(err) {
+			blog.Errorf("create %s index(%v) failed, err: %v", tableName, idx, err)
+			return err
 		}
 
 	}

--- a/src/scene_server/admin_server/upgrader/y3.9.202106291420/pkg.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202106291420/pkg.go
@@ -21,12 +21,11 @@ import (
 )
 
 func init() {
-
 	upgrader.RegistUpgrader("y3.9.202106291420", upgrade)
 }
 
 func upgrade(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error) {
-	err = addIndexex(ctx, db, conf)
+	err = addIndexes(ctx, db, conf)
 	if err != nil {
 		blog.Errorf("[upgrade y3.9.202106291420] index error  %s", err.Error())
 		return err

--- a/src/test/topo_server/set_template_test.go
+++ b/src/test/topo_server/set_template_test.go
@@ -1079,6 +1079,7 @@ func prepareSetTemplateData() {
 			"language":          "1",
 		}
 		rsp, err := topoServerClient.Instance().CreateApp(ctx, common.BKDefaultOwnerID, header, data)
+		testutil.RegisterResponseWithRid(rsp, header)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rsp.BaseResp.Result).To(Equal(true))
 		Expect(rsp.Data[common.BKAppIDField]).To(Not(Equal(int64(0))))
@@ -1094,6 +1095,7 @@ func prepareSetTemplateData() {
 			"name":              "root0",
 		}
 		rsp, err := serviceClient.CreateServiceCategory(context.Background(), header, input)
+		testutil.RegisterResponseWithRid(rsp, header)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
 			"Result": Equal(true),
@@ -1113,6 +1115,7 @@ func prepareSetTemplateData() {
 			"name":              "child0",
 		}
 		rsp, err := serviceClient.CreateServiceCategory(context.Background(), header, input)
+		testutil.RegisterResponseWithRid(rsp, header)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
 			"Result": Equal(true),
@@ -1132,6 +1135,7 @@ func prepareSetTemplateData() {
 			"service_category_id": categoryId,
 		}
 		rsp, err := procServerClient.Service().CreateServiceTemplate(ctx, header, data)
+		testutil.RegisterResponseWithRid(rsp, header)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
 			"Result": Equal(true),
@@ -1150,6 +1154,7 @@ func prepareSetTemplateData() {
 			"service_category_id": categoryId,
 		}
 		rsp, err := procServerClient.Service().CreateServiceTemplate(ctx, header, data)
+		testutil.RegisterResponseWithRid(rsp, header)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
 			"Result": Equal(true),
@@ -1168,6 +1173,7 @@ func prepareSetTemplateData() {
 			"service_category_id": categoryId,
 		}
 		rsp, err := procServerClient.Service().CreateServiceTemplate(ctx, header, data)
+		testutil.RegisterResponseWithRid(rsp, header)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
 			"Result": Equal(true),

--- a/src/web_server/service/util.go
+++ b/src/web_server/service/util.go
@@ -160,8 +160,9 @@ func (s *Service) getUserListStr(userList []string) []string {
 	userBuffer := bytes.Buffer{}
 	for _, user := range userList {
 		if userBuffer.Len()+len(user) > getUserMaxLength {
+			userBuffer.WriteString(user)
 			userStr := userBuffer.String()
-			userListStr = append(userListStr, userStr[:len(userStr)-1])
+			userListStr = append(userListStr, userStr)
 			userBuffer.Reset()
 			continue
 		}


### PR DESCRIPTION
### 修复的问题：
- 导出带用户数据时，处理用户数据丢失问题
- upgrader中创建索引时兼容已经创建过的重复索引