### PR TITLE
表格字段添加默认值后，编辑修改勾选设置“当前列的值必填”不生效

### DIFF
--- a/src/scene_server/topo_server/logics/model/attribute.go
+++ b/src/scene_server/topo_server/logics/model/attribute.go
@@ -366,10 +366,12 @@ func (a *attribute) ValidTableAttrDefaultValue(kit *rest.Kit, defaultValue []map
 	// value according to the attributes of the header.
 	for _, value := range defaultValue {
 		for k, v := range value {
+			isRequired := attr[k].IsRequired
 			attr[k].IsRequired = false
 			if err := attr[k].ValidTableDefaultAttr(kit.Ctx, v); err.ErrCode != 0 {
 				return err.ToCCError(kit.CCError)
 			}
+			attr[k].IsRequired = isRequired
 		}
 	}
 	return nil
@@ -1136,7 +1138,7 @@ func (a *attribute) UpdateTableObjectAttr(kit *rest.Kit, data mapstr.MapStr, att
 	}
 
 	// updated this part is to be updated
-	if err := a.ValidTableAttrDefaultValue(kit, updated.Default, headerMap); err != nil {
+	if err = a.ValidTableAttrDefaultValue(kit, updated.Default, headerMap); err != nil {
 		blog.Errorf("valid table attr default failed, err: %v, rid: %s", err, kit.Rid)
 		return err
 	}


### PR DESCRIPTION
### 修复的问题：
- 表格字段添加默认值后，编辑修改勾选设置“当前列的值必填”不生效

close #7307