### PR TITLE
修复服务模板同步超时的问题

### DIFF
--- a/src/common/metadata/instance_struct.go
+++ b/src/common/metadata/instance_struct.go
@@ -51,3 +51,15 @@ type BizSetInstanceData struct {
 	Count int          `json:"count"`
 	Info  []BizSetInst `json:"info"`
 }
+
+// ProcInstanceResponse process instance response
+type ProcInstanceResponse struct {
+	BaseResp `json:",inline"`
+	Data     ProcInstanceData `json:"data"`
+}
+
+// ProcInstanceData 进程查询接口响应数据
+type ProcInstanceData struct {
+	Count int       `json:"count"`
+	Info  []Process `json:"info"`
+}

--- a/src/common/metadata/process.go
+++ b/src/common/metadata/process.go
@@ -194,6 +194,16 @@ func (option *ServiceTemplateDiffOption) ServiceTemplateOptionValidate() cErr.Ra
 	return cErr.RawErrorInfo{}
 }
 
+// SyncServiceTemplateOption sync service template to some hosts in a module.
+type SyncServiceTemplateOption struct {
+	BizID             int64   `json:"bk_biz_id"`
+	ServiceTemplateID int64   `json:"service_template_id"`
+	ModuleID          int64   `json:"bk_module_id"`
+	HostIDs           []int64 `json:"bk_host_ids,omitempty"`
+	// IsSyncModule defines if module attributes needs to be synced, or if hosts needs to be synced
+	IsSyncModule bool `json:"is_sync_module"`
+}
+
 // ListDiffServiceInstancesOption list service instances request.
 type ListDiffServiceInstancesOption struct {
 	BizID             int64 `json:"bk_biz_id"`

--- a/src/scene_server/proc_server/logics/processinstance.go
+++ b/src/scene_server/proc_server/logics/processinstance.go
@@ -94,7 +94,7 @@ func (lgc *Logic) ListProcessInstances(kit *rest.Kit, bizID int64, serviceInstan
 	return processInstanceList, nil
 }
 
-// ListProcessInstanceWithIDs TODO
+// ListProcessInstanceWithIDs list process instance with ids
 func (lgc *Logic) ListProcessInstanceWithIDs(kit *rest.Kit, procIDs []int64) ([]metadata.Process, errors.CCErrorCoder) {
 	reqParam := &metadata.QueryCondition{
 		Condition: mapstr.MapStr(map[string]interface{}{
@@ -102,24 +102,18 @@ func (lgc *Logic) ListProcessInstanceWithIDs(kit *rest.Kit, procIDs []int64) ([]
 				common.BKDBIN: procIDs,
 			},
 		}),
+		DisableCounter: true,
 	}
-	ret, err := lgc.CoreAPI.CoreService().Instance().ReadInstance(kit.Ctx, kit.Header, common.BKInnerObjIDProc,
-		reqParam)
+
+	ret := new(metadata.ProcInstanceResponse)
+	err := lgc.CoreAPI.CoreService().Instance().ReadInstanceStruct(kit.Ctx, kit.Header, common.BKInnerObjIDProc,
+		reqParam, ret)
 	if nil != err {
 		blog.Errorf("rid: %s list process instance with procID: %d failed, err: %v", kit.Rid, procIDs, err)
 		return nil, kit.CCError.CCError(common.CCErrCommHTTPDoRequestFailed)
 	}
 
-	processes := make([]metadata.Process, 0)
-	for _, p := range ret.Info {
-		process := new(metadata.Process)
-		if err := p.MarshalJSONInto(process); err != nil {
-			return nil, kit.CCError.CCError(common.CCErrCommJSONUnmarshalFailed)
-		}
-		processes = append(processes, *process)
-	}
-
-	return processes, nil
+	return ret.Data.Info, nil
 }
 
 // GetProcessInstanceWithID TODO

--- a/src/scene_server/task_server/taskconfig/taskconfig.go
+++ b/src/scene_server/task_server/taskconfig/taskconfig.go
@@ -41,7 +41,7 @@ var (
 // init task queue
 func init() {
 	AddCodeTaskConfig(common.SyncSetTaskFlag, types.CC_MODULE_TOPO, "/topo/v3/internal/sync/module/task", 1, 2)
-	AddCodeTaskConfig(common.SyncModuleTaskFlag, types.CC_MODULE_PROC, "/process/v3/sync/service_instance/task", 1, 2)
+	AddCodeTaskConfig(common.SyncModuleTaskFlag, types.CC_MODULE_PROC, "/process/v3/sync/service_instance/task", 1, 10)
 	AddCodeTaskConfig(common.SyncModuleHostApplyTaskFlag, types.CC_MODULE_HOST,
 		"/host/v3/updatemany/module/host_apply_plan/task", 1, 2)
 	AddCodeTaskConfig(common.SyncServiceTemplateHostApplyTaskFlag, types.CC_MODULE_PROC,


### PR DESCRIPTION
服务模板同步目前是按照模块维度进行同步的，服务模板里进程较多且模块里主机较多的情况下会超时。

- 解决方案：
在原有的模块维度下按主机维度拆单，按主机数*进程数<=1000拆单，防止task-server回调超时（默认http请求超时时间25s，默认请求的context超时时间为2分钟，mongodb事务默认超时时间为60s）

- 影响：
原本一个模块的同步是在一个事务里的，现在拆单后是一批主机为一个事务。理论上在同步的场景下只要做到可重入就可以，所以拆单应该是可以接受的
