### PR TITLE
修复预览动态分组时提示：‘获取自定义查询详情失败, HTTP请求失败’的问题

### DIFF
--- a/src/common/metadata/dynamic_grouping.go
+++ b/src/common/metadata/dynamic_grouping.go
@@ -15,6 +15,7 @@ package metadata
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"time"
 
 	"configcenter/src/common"
@@ -144,6 +145,29 @@ func (c *DynamicGroupCondition) Validate(attributeMap map[string]string) error {
 	return nil
 }
 
+// VerifyRegexValidity 验证正则表达式的合法性
+func (c *DynamicGroupCondition) VerifyRegexValidity() error {
+	//验证 value 是否为空
+	if c.Value == nil {
+		blog.Errorf("HTTP request body data is not set, err: value not set, regex: %v", c.Value)
+		return errors.New("value not set")
+	}
+	//模糊匹配时需要验证正则表达式的合法性
+	if c.Operator != common.BKDBLIKE {
+		return nil
+	}
+	strValue := util.GetStrByInterface(c.Value)
+	if strValue == "" {
+		blog.Errorf("HTTP request body data is not set, err: value not set, regex: %v", c.Value)
+		return errors.New("value not set")
+	}
+	if _, err := regexp.Compile(strValue); err != nil {
+		blog.Errorf("the regular expression's type assertion failed, err: %v, regex: %v", err, c.Value)
+		return err
+	}
+	return nil
+}
+
 func validAttributeValueType(attrType string, value interface{}) error {
 	switch attrType {
 	case stringType:
@@ -246,6 +270,13 @@ func (c *DynamicGroupInfo) Validate(objectID string, validatefunc Validatefunc) 
 	}
 
 	for _, cond := range c.Condition {
+		for _, item := range cond.Condition {
+			if err := item.VerifyRegexValidity(); err != nil {
+				blog.Errorf("verify regex validity failed, err: %v, input: %v, objectID: %s", err, item, objectID)
+				return err
+			}
+		}
+
 		if _, isSupport = types[cond.ObjID]; !isSupport {
 			return fmt.Errorf("not support condition type[%s] for %s dynamic group", cond.ObjID, objectID)
 		}

--- a/src/common/metadata/dynamic_grouping.go
+++ b/src/common/metadata/dynamic_grouping.go
@@ -147,12 +147,12 @@ func (c *DynamicGroupCondition) Validate(attributeMap map[string]string) error {
 
 // VerifyRegexValidity 验证正则表达式的合法性
 func (c *DynamicGroupCondition) VerifyRegexValidity() error {
-	//验证 value 是否为空
+	// 验证 value 是否为空
 	if c.Value == nil {
 		blog.Errorf("HTTP request body data is not set, err: value not set, regex: %v", c.Value)
 		return errors.New("value not set")
 	}
-	//模糊匹配时需要验证正则表达式的合法性
+	// 模糊匹配时需要验证正则表达式的合法性
 	if c.Operator != common.BKDBLIKE {
 		return nil
 	}


### PR DESCRIPTION
### 修复的问题：
修复预览动态分组时提示：‘获取自定义查询详情失败, HTTP请求失败’的问题
