### PR TITLE
修复导出主机时报错no matched rules的问题

### DIFF
--- a/src/ac/parser/topolatest.go
+++ b/src/ac/parser/topolatest.go
@@ -308,6 +308,8 @@ const (
 	findObjectAssociationLatestPattern                    = "/api/v3/find/objectassociation"
 	createObjectAssociationLatestPattern                  = "/api/v3/create/objectassociation"
 	findObjectAssociationWithAssociationKindLatestPattern = "/api/v3/find/topoassociationtype"
+	// excel 导入主机专用接口
+	findModelAssociationPattern = "/api/v3/find/instassociation/model"
 )
 
 var (
@@ -321,6 +323,7 @@ var (
 		`^/api/v3/import/instassociation/[^\s/]+$`)
 )
 
+// NOCC:golint/fnsize(设计如此)
 func (ps *parseStream) objectAssociationLatest() *parseStream {
 	if ps.shouldReturn() {
 		return ps
@@ -535,6 +538,19 @@ func (ps *parseStream) objectAssociationLatest() *parseStream {
 		ps.Attribute.Resources = []meta.ResourceAttribute{
 			{
 				BusinessID: 0,
+				Basic: meta.Basic{
+					Type:   meta.ModelAssociation,
+					Action: meta.SkipAction,
+				},
+			},
+		}
+		return ps
+	}
+
+	// excel 导入主机专用接口, 跳过鉴权
+	if ps.hitPattern(findModelAssociationPattern, http.MethodPost) {
+		ps.Attribute.Resources = []meta.ResourceAttribute{
+			{
 				Basic: meta.Basic{
 					Type:   meta.ModelAssociation,
 					Action: meta.SkipAction,
@@ -1170,8 +1186,11 @@ var (
 
 	searchObjectInstancesRegexp = regexp.MustCompile(`^/api/v3/search/instances/object/[^\s/]+/?$`)
 	countObjectInstancesRegexp  = regexp.MustCompile(`^/api/v3/count/instances/object/[^\s/]+/?$`)
+	// excel 导入主机专用接口
+	findObjectInstancesForExcelRegexp = regexp.MustCompile(`^/api/v3/find/instance/[^\s/]+/?$`)
 )
 
+// NOCC:golint/fnsize(设计如此)
 func (ps *parseStream) objectInstanceLatest() *parseStream {
 	if ps.shouldReturn() {
 		return ps
@@ -1726,6 +1745,18 @@ func (ps *parseStream) objectInstanceLatest() *parseStream {
 			{
 				Basic: meta.Basic{
 					Type:   instanceType,
+					Action: meta.SkipAction,
+				},
+			},
+		}
+		return ps
+	}
+
+	// excel 导入主机专用接口, 跳过鉴权
+	if ps.hitRegexp(findObjectInstancesForExcelRegexp, http.MethodPost) {
+		ps.Attribute.Resources = []meta.ResourceAttribute{
+			{
+				Basic: meta.Basic{
 					Action: meta.SkipAction,
 				},
 			},

--- a/src/apimachinery/apiserver/api.go
+++ b/src/apimachinery/apiserver/api.go
@@ -506,12 +506,13 @@ func (a *apiServer) ListHostWithoutApp(ctx context.Context, h http.Header,
 }
 
 // ReadModuleAssociation get mainline topo model association
-func (a *apiServer) ReadModuleAssociation(ctx context.Context, h http.Header,
-	cond *metadata.QueryCondition) (resp *metadata.SearchAsstModelResp, err error) {
-	resp = new(metadata.SearchAsstModelResp)
+func (a *apiServer) ReadModuleAssociation(ctx context.Context, h http.Header, cond *metadata.QueryCondition) (
+	*metadata.AsstResult, ccErr.CCErrorCoder) {
+
+	resp := new(metadata.SearchAsstModelResp)
 	subPath := "/find/instassociation/model"
 
-	err = a.client.Post().
+	err := a.client.Post().
 		WithContext(ctx).
 		Body(cond).
 		SubResourcef(subPath).
@@ -519,7 +520,15 @@ func (a *apiServer) ReadModuleAssociation(ctx context.Context, h http.Header,
 		Do().
 		Into(resp)
 
-	return
+	if err != nil {
+		return nil, ccErr.CCHttpError
+	}
+
+	if err := resp.CCError(); err != nil {
+		return nil, err
+	}
+
+	return &resp.Data, nil
 }
 
 // ReadModel read object model data by obj id

--- a/src/apimachinery/apiserver/apiserver.go
+++ b/src/apimachinery/apiserver/apiserver.go
@@ -95,12 +95,12 @@ type ApiServerClientInterface interface {
 	SearchBiz(ctx context.Context, ownerID string, h http.Header,
 		s *params.SearchParams) (resp *metadata.SearchInstResult, err error)
 
-	ReadModuleAssociation(ctx context.Context, h http.Header, input *metadata.QueryCondition) (resp *metadata.
-		SearchAsstModelResp, err error)
+	ReadModuleAssociation(ctx context.Context, h http.Header, cond *metadata.QueryCondition) (*metadata.AsstResult,
+		errors.CCErrorCoder)
 	ReadModel(ctx context.Context, h http.Header, input *metadata.QueryCondition) (*metadata.QueryModelDataResult,
 		errors.CCErrorCoder)
-	ReadInstance(ctx context.Context, h http.Header, objID string, input *metadata.QueryCondition) (resp *metadata.
-		QueryConditionResult, err error)
+	ReadInstance(ctx context.Context, h http.Header, objID string, input *metadata.QueryCondition) (
+		resp *metadata.QueryConditionResult, err error)
 	SearchObjectUnique(ctx context.Context, objID string, h http.Header) (resp *metadata.SearchUniqueResult, err error)
 
 	FindAssociationByObjectAssociationID(ctx context.Context, h http.Header, objID string,

--- a/src/web_server/service/host.go
+++ b/src/web_server/service/host.go
@@ -520,7 +520,7 @@ func (s *Service) getCustomObjectInfo(ctx context.Context, header http.Header) (
 	}
 
 	mainlineObjectChildMap := make(map[string]string, 0)
-	for _, asst := range mainlineAsstRsp.Data.Info {
+	for _, asst := range mainlineAsstRsp.Info {
 		if asst.ObjectID == common.BKInnerObjIDHost {
 			continue
 		}


### PR DESCRIPTION
需要注意：之前导出主机时查询自定义层级报错no matched rules，这个报错会被忽略，导致如果有自定义层级的话是不会导出出来的，修复后会导出自定义层级
