### PR TITLE
修复启动adminserver时，由于Service.Logics还没赋值导致panic的问题

### DIFF
--- a/docs/support-file/changelog/release.md
+++ b/docs/support-file/changelog/release.md
@@ -1,3 +1,7 @@
+## [Version: v3.11.2-alpha4] - 2023-09-20
+**缺陷修复**
+- 修复启动adminserver时，由于Service.Logics还没赋值导致panic的问题
+
 ## [Version: v3.11.2-alpha3] - 2023-09-18
 **功能优化**
 - 优化了一些前端的显示问题

--- a/docs/support-file/helm/Chart.yaml
+++ b/docs/support-file/helm/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 3.11.2-alpha3
+appVersion: 3.11.2-alpha4
 description: BlueKing Configuration Management DataBase (bk-cmdb) is an enterprise level configuration management serivce database.
 name: bk-cmdb
 type: application
-version: 3.12.2-alpha3
+version: 3.12.2-alpha4
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
### 修复的问题：
- 修复启动adminserver时，由于Service.Logics还没赋值导致panic的问题
