### PR TITLE
修复模型属性字段导出时默认值并未被导出、导入时报错信息不规范和日期/时间/用户/时区/列表这四个字段没做任何变动导入时报错问题

### DIFF
--- a/src/source_controller/coreservice/service/model.go
+++ b/src/source_controller/coreservice/service/model.go
@@ -590,8 +590,13 @@ func (s *coreService) UpdateModelAttributes(ctx *rest.Contexts) {
 		return
 	}
 
-	ctx.RespEntityWithError(s.core.ModelOperation().UpdateModelAttributes(ctx.Kit,
-		ctx.Request.PathParameter("bk_obj_id"), inputData))
+	updateCount, err := s.core.ModelOperation().UpdateModelAttributes(ctx.Kit, ctx.Request.PathParameter("bk_obj_id"),
+		inputData)
+	if err != nil {
+		ctx.RespAutoError(err)
+		return
+	}
+	ctx.RespEntity(updateCount)
 }
 
 // UpdateModelAttributesIndex update model attribute

--- a/src/web_server/service/excel/operator/model/operator.go
+++ b/src/web_server/service/excel/operator/model/operator.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"configcenter/pkg/excel"
 	"configcenter/src/common"
@@ -302,6 +303,9 @@ func (op *Operator) getImportAttr() (map[int]map[string]interface{}, error) {
 			}
 
 			if idTypeMap[id] != boolType {
+				if id == common.BKDefaultField {
+					val = strings.Trim(val, `"`)
+				}
 				attr[id] = val
 				continue
 			}


### PR DESCRIPTION
### 修复的问题：
- 修复模型属性字段导出excel时枚举、枚举多选、表格字段的默认值没有导出 --- 定义为正常
- 修复模型属性字段excel导入时报错信息不规范
- 修复模型属性字段excel中日期/时间/用户/时区/列表这四个字段没做任何变动导入时报错问题
issue：https://github.com/TencentBlueKing/bk-cmdb/issues/6775