### PR TITLE
fix: 容器主机列表搜索为空样式规范

### DIFF
--- a/src/ui/src/views/business-topology/host/host-list.vue
+++ b/src/ui/src/views/business-topology/host/host-list.vue
@@ -370,14 +370,16 @@
           cancelPrevious: true
         }
 
-        if (this.isContainerHost) {
-          return containerHostService.findAll(params, config)
-        }
         const { filter, ip } = this.$route.query
         this.table.stuff.type = (filter || ip)  ? 'search' : 'default'
         if (params.ip.data.length > 0) {
           this.table.stuff.type = 'search'
         }
+
+        if (this.isContainerHost) {
+          return containerHostService.findAll(params, config)
+        }
+
         return this.$store.dispatch('hostSearch/searchHost', { params, config })
       },
       getParams() {


### PR DESCRIPTION
### 修复的问题：
- 容器主机列表搜索为空样式规范
