### PR TITLE
chore: bump bk-magic-vue to 2.5.8

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -21,7 +21,7 @@
     "@icon-cool/bk-icon-cmdb-colorful": "0.0.1",
     "await-to-js": "^3.0.0",
     "axios": "0.18.0",
-    "bk-magic-vue": "2.5.8-beta.11",
+    "bk-magic-vue": "2.5.8",
     "core-js": "^3.10.1",
     "cytoscape": "3.10.0",
     "cytoscape-dagre": "2.2.2",


### PR DESCRIPTION
### 修复的问题：
- 解决依赖冲突
