### PR TITLE
fix: 资源页面中，右侧面板面包屑都带上返回箭头，返回到“资源目录”页面

### DIFF
--- a/src/ui/src/views/business-set/router.config.js
+++ b/src/ui/src/views/business-set/router.config.js
@@ -13,7 +13,8 @@
 import Meta from '@/router/meta'
 import {
   MENU_RESOURCE_BUSINESS_SET,
-  MENU_RESOURCE_BUSINESS_SET_DETAILS
+  MENU_RESOURCE_BUSINESS_SET_DETAILS,
+  MENU_RESOURCE_MANAGEMENT
 } from '@/dictionary/menu-symbol.js'
 
 export default [
@@ -23,7 +24,8 @@ export default [
     component: () => import('./index.vue'),
     meta: new Meta({
       menu: {
-        i18n: '业务集'
+        i18n: '业务集',
+        relative: MENU_RESOURCE_MANAGEMENT
       }
     })
   },

--- a/src/ui/src/views/business/router.config.js
+++ b/src/ui/src/views/business/router.config.js
@@ -14,7 +14,8 @@ import Meta from '@/router/meta'
 import {
   MENU_RESOURCE_BUSINESS,
   MENU_RESOURCE_BUSINESS_DETAILS,
-  MENU_RESOURCE_BUSINESS_HISTORY
+  MENU_RESOURCE_BUSINESS_HISTORY,
+  MENU_RESOURCE_MANAGEMENT
 } from '@/dictionary/menu-symbol'
 
 import { OPERATION } from '@/dictionary/iam-auth'
@@ -24,7 +25,8 @@ export default [{
   component: () => import('./index.vue'),
   meta: new Meta({
     menu: {
-      i18n: '业务'
+      i18n: '业务',
+      relative: MENU_RESOURCE_MANAGEMENT
     },
     layout: {}
   })

--- a/src/ui/src/views/project/router.config.js
+++ b/src/ui/src/views/project/router.config.js
@@ -11,7 +11,7 @@
  */
 
 import Meta from '@/router/meta'
-import { MENU_RESOURCE_PROJECT, MENU_RESOURCE_PROJECT_DETAILS } from '@/dictionary/menu-symbol'
+import { MENU_RESOURCE_PROJECT, MENU_RESOURCE_PROJECT_DETAILS, MENU_RESOURCE_MANAGEMENT } from '@/dictionary/menu-symbol'
 import { OPERATION } from '@/dictionary/iam-auth'
 
 export default [
@@ -21,7 +21,8 @@ export default [
     component: () => import('./index.vue'),
     meta: new Meta({
       menu: {
-        i18n: '项目'
+        i18n: '项目',
+        relative: MENU_RESOURCE_MANAGEMENT
       },
       auth: {
         view: { type: OPERATION.R_PROJECT }

--- a/src/ui/src/views/resource/router.config.js
+++ b/src/ui/src/views/resource/router.config.js
@@ -26,7 +26,8 @@ export default [{
   component: () => import('./index.vue'),
   meta: new Meta({
     menu: {
-      i18n: '主机'
+      i18n: '主机',
+      relative: MENU_RESOURCE_MANAGEMENT
     },
     layout: {},
     auth: {


### PR DESCRIPTION
### 修复的问题：
- 资源页面中，除了「管控区域、云账号、云资源发现」外，右侧面板面包屑都带上返回箭头，返回到“资源目录”页面
