### PR TITLE
修复创建主线拓扑节点时，可以使用string类型的bk_parent_id的问题

### DIFF
--- a/src/source_controller/coreservice/core/instances/instance_validate.go
+++ b/src/source_controller/coreservice/core/instances/instance_validate.go
@@ -450,7 +450,8 @@ func (m *instanceManager) validMainlineInstanceData(kit *rest.Kit, objID string,
 
 	// validate bk_parent_id
 	if instanceData.Exists(common.BKParentIDField) {
-		if parentID, err := instanceData.Int64(common.BKParentIDField); err != nil || parentID <= 0 {
+		parentID, err := util.GetInt64ByInterface(instanceData[common.BKParentIDField])
+		if err != nil || parentID <= 0 {
 			blog.Errorf("invalid bk_parent_id value: %#v, err: %v, rid: %s", instanceData[common.BKParentIDField], err,
 				kit.Rid)
 			return kit.CCError.CCErrorf(common.CCErrCommParamsInvalid, common.BKParentIDField)


### PR DESCRIPTION
### 修复的问题：
- 修复创建主线拓扑节点时，可以使用string类型的bk_parent_id的问题
