### PR TITLE
修复cmdb导入模型后，模型的顺序会被打乱问题；修复在删除模型时，模型排序序号不连续问题；

### DIFF
--- a/src/common/metadata/object.go
+++ b/src/common/metadata/object.go
@@ -327,6 +327,7 @@ type YamlObject struct {
 	ObjectName       string                `json:"bk_obj_name" yaml:"bk_obj_name"`
 	ObjIcon          string                `json:"bk_obj_icon" yaml:"bk_obj_icon"`
 	IsPre            bool                  `json:"ispre" yaml:"ispre"`
+	ObjSortNumber    int64                 `json:"obj_sort_number" yaml:"obj_sort_number"`
 	ClsID            string                `json:"bk_classification_id" yaml:"bk_classification_id"`
 	ClsName          string                `json:"bk_classification_name" yaml:"bk_classification_name"`
 	ObjectAsst       []AsstWithAsstObjInfo `json:"object_asst" yaml:"object_asst"`

--- a/src/scene_server/topo_server/logics/model/object.go
+++ b/src/scene_server/topo_server/logics/model/object.go
@@ -810,6 +810,7 @@ func (o *object) CreateObjectByImport(kit *rest.Kit, data []metadata.YamlObject)
 			common.BKObjIconField:          objInfo.ObjIcon,
 			common.BKClassificationIDField: objInfo.ClsID,
 			common.CreatorField:            kit.User,
+			common.ObjSortNumberField:      objInfo.ObjSortNumber,
 		}
 
 		obj, err := o.isValid(kit, false, object)
@@ -1126,7 +1127,7 @@ func (o *object) SearchObjectsWithTotalInfo(kit *rest.Kit, ids, excludedAsst []i
 	objCond := metadata.QueryCondition{
 		Condition: mapstr.MapStr{common.BKFieldID: mapstr.MapStr{common.BKDBIN: ids}},
 		Fields: []string{common.BKObjIDField, common.BKObjNameField, common.BKClassificationIDField,
-			common.BKObjIconField, common.BKIsPre},
+			common.BKObjIconField, common.BKIsPre, common.ObjSortNumberField},
 		DisableCounter: true,
 	}
 	objs, err := o.searchObjectByCondition(kit, objCond)
@@ -1192,6 +1193,7 @@ func (o *object) SearchObjectsWithTotalInfo(kit *rest.Kit, ids, excludedAsst []i
 			common.BKObjIconField:          obj.ObjIcon,
 			common.BKClassificationIDField: obj.ObjCls,
 			common.BKIsPre:                 obj.IsPre,
+			common.ObjSortNumberField:      obj.ObjSortNumber,
 		}
 		objInfo[common.BKClassificationNameField] = clsMap[obj.ObjCls]
 		objInfo["object_attr"] = attrRsp[objID]


### PR DESCRIPTION
### 修复的问题：
- 修复cmdb导入模型后，模型的顺序会被打乱问题；
- 修复在删除模型时，模型排序序号不连续问题；
