### PR TITLE
修复接口涉及到创建时间与更新时间的字段参数不填写的，都会报未知的错误

### DIFF
--- a/src/source_controller/coreservice/core/instances/instance.go
+++ b/src/source_controller/coreservice/core/instances/instance.go
@@ -107,8 +107,9 @@ func (m *instanceManager) CreateModelInstance(kit *rest.Kit, objID string,
 }
 
 // CreateManyModelInstance create model instances
-func (m *instanceManager) CreateManyModelInstance(kit *rest.Kit, objID string,
-	inputParam metadata.CreateManyModelInstance) (*metadata.CreateManyDataResult, error) {
+func (m *instanceManager) CreateManyModelInstance(kit *rest.Kit,
+	objID string, inputParam metadata.CreateManyModelInstance) (
+	*metadata.CreateManyDataResult, error) {
 
 	dataResult := new(metadata.CreateManyDataResult)
 	if len(inputParam.Datas) == 0 {

--- a/src/source_controller/coreservice/core/instances/instance_validate.go
+++ b/src/source_controller/coreservice/core/instances/instance_validate.go
@@ -495,6 +495,10 @@ func (m *instanceManager) changeStringToTime(valData mapstr.MapStr, properties [
 		if field.PropertyType != common.FieldTypeTime {
 			continue
 		}
+		if field.PropertyID == common.BKCreatedAt || field.PropertyID == common.BKUpdatedAt {
+			// ignore the key field
+			continue
+		}
 		val, ok := valData[field.PropertyID]
 		if ok == false || val == nil {
 			continue


### PR DESCRIPTION
### 修复的问题：
- 对应issue：https://github.com/TencentBlueKing/bk-cmdb/issues/7626
- 模型实例的创建时间和更新时间字段不可由用户指定，应当在新增或更新时由系统生成，如果在创建或更新时用户传递了相应字段则移除
