### PR TITLE
修复操作审计当不存在某字段时，需要跳过，防止对比出现差异记录了审计

### DIFF
--- a/src/scene_server/datacollection/collections/hostsnap/hostsnap.go
+++ b/src/scene_server/datacollection/collections/hostsnap/hostsnap.go
@@ -284,6 +284,10 @@ func needToUpdate(src, toCompare string) bool {
 			// 忽略变更对比的字段直接过滤掉
 			continue
 		}
+		// 当不存在该字段时，需要跳过，防止对比出现差异记录了审计
+		if !srcElements[idx].Exists() {
+			continue
+		}
 		// compare these value with string directly to avoid empty value or null value.
 		if srcElements[idx].String() != compareElements[idx].String() {
 			compareField := compareFields[idx]


### PR DESCRIPTION
### 修复的问题：
- 在采集器上报的数据中，有些数据记录可能为空，此时在cmdb中解析出来的数据中就没有该字段了，此处修复操作审计当不存在某字段时，需要跳过对比，防止对比出现差异记录了审计，3.10版本同样已做了该优化，此处在3.9版本做优化
