### PR TITLE
修复批量同步服务模板实例的属性时，只有一个成功的问题

### DIFF
--- a/src/scene_server/proc_server/service/serviceinstance.go
+++ b/src/scene_server/proc_server/service/serviceinstance.go
@@ -1926,6 +1926,8 @@ func (ps *ProcServer) SyncServiceInstanceByTemplate(ctx *rest.Contexts) {
 	tasks := make([]metadata.CreateTaskRequest, 0)
 	for _, moduleID := range syncOpt.ModuleIDs {
 		syncOneModuleOpt.ModuleID = moduleID
+		syncOneModuleOpt.HostIDs = nil
+		syncOneModuleOpt.IsSyncModule = true
 
 		taskReq := metadata.CreateTaskRequest{
 			TaskType: common.SyncModuleTaskFlag,


### PR DESCRIPTION
### 修复的问题：
- 修复批量同步服务模板实例的属性时，只有一个成功的问题
