### PR TITLE
修复导入动态寻址方式的主机时显示导入成功但主机不存在的问题

### DIFF
--- a/src/web_server/service/excel/operator/inst/importer/importer.go
+++ b/src/web_server/service/excel/operator/inst/importer/importer.go
@@ -706,6 +706,7 @@ func (i *Importer) checkAddedHost(hosts map[int]map[string]interface{}) (map[int
 
 		// in dynamic scenarios, there is no need to do duplication check of ip address.
 		if addressType == common.BKAddressingDynamic {
+			legalHost[index] = host
 			continue
 		}
 


### PR DESCRIPTION
### 修复的问题：
- 修复导入动态寻址方式的主机时显示导入成功但主机不存在的问题
