### PR TITLE
添加模型引用类型、字段组合模板功能测试用例

### DIFF
--- a/src/apimachinery/toposerver/fieldtemplate/api.go
+++ b/src/apimachinery/toposerver/fieldtemplate/api.go
@@ -1,0 +1,104 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云 - 配置平台 (BlueKing - Configuration System) available.
+ * Copyright (C) 2017 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+// Package fieldtemplate Package fieldtmpl defines field template api machinery.
+package fieldtemplate
+
+import (
+	"context"
+	"net/http"
+
+	"configcenter/src/apimachinery/rest"
+	"configcenter/src/common/errors"
+	"configcenter/src/common/metadata"
+)
+
+// FieldTemplateInterface field template interface
+type FieldTemplateInterface interface {
+	// field template
+	ListFieldTemplate(ctx context.Context, h http.Header, opt metadata.CommonQueryOption) (
+		*metadata.ListFieldTemplateResp, errors.CCErrorCoder)
+	CreateFieldTemplate(ctx context.Context, header http.Header, option metadata.CreateFieldTmplOption) (
+		*metadata.CreateResult, errors.CCErrorCoder)
+	FindFieldTemplateByID(ctx context.Context, header http.Header, fieldTemplateID int64) (
+		*metadata.FieldTemplateResp, errors.CCErrorCoder)
+	FieldTemplateBindObject(ctx context.Context, header http.Header, option metadata.FieldTemplateBindObjOpt) (
+		*metadata.Response, errors.CCErrorCoder)
+	FieldTemplateUnbindObject(ctx context.Context, header http.Header, option metadata.FieldTemplateUnbindObjOpt) (
+		*metadata.Response, errors.CCErrorCoder)
+	DeleteFieldTemplate(ctx context.Context, header http.Header, option metadata.DeleteFieldTmplOption) (
+		*metadata.Response, errors.CCErrorCoder)
+	CloneFieldTemplate(ctx context.Context, header http.Header, option metadata.CloneFieldTmplOption) (
+		*metadata.CreateResult, errors.CCErrorCoder)
+	UpdateFieldTemplate(ctx context.Context, header http.Header, option metadata.UpdateFieldTmplOption) (
+		*metadata.Response, errors.CCErrorCoder)
+	UpdateFieldTemplateInfo(ctx context.Context, header http.Header, option metadata.FieldTemplate) (
+		*metadata.Response, errors.CCErrorCoder)
+
+	// field template attribute
+	ListFieldTemplateAttr(ctx context.Context, h http.Header, opt metadata.ListFieldTmplAttrOption) (
+		*metadata.ListFieldTemplateAttrResp, errors.CCErrorCoder)
+	CountFieldTemplateAttr(ctx context.Context, header http.Header, option metadata.CountFieldTmplResOption) (
+		*metadata.CountFieldTemplateAttrResult, errors.CCErrorCoder)
+
+	// field template unique
+	ListFieldTemplateUnique(ctx context.Context, header http.Header, option metadata.ListFieldTmplUniqueOption) (
+		*metadata.ListFieldTmplUniqueResp, errors.CCErrorCoder)
+
+	// field template sync to object
+	SyncFieldTemplateInfoToObjects(ctx context.Context, header http.Header, option metadata.FieldTemplateSyncOption) (
+		*metadata.Response, errors.CCErrorCoder)
+	ListObjFieldTmplRel(ctx context.Context, header http.Header, option metadata.ListObjFieldTmplRelOption) (
+		*metadata.ListObjFieldTmplRelResp, errors.CCErrorCoder)
+	ListFieldTmplByObj(ctx context.Context, header http.Header, option metadata.ListFieldTmplByObjOption) (
+		*metadata.ListFieldTemplateResp, errors.CCErrorCoder)
+	ListObjByFieldTmpl(ctx context.Context, header http.Header, option metadata.ListObjByFieldTmplOption) (
+		*metadata.ReadModelResult, errors.CCErrorCoder)
+
+	// field template task
+	SyncFieldTemplateToObjectTask(ctx context.Context, header http.Header, option metadata.SyncObjectTask) (
+		*metadata.Response, errors.CCErrorCoder)
+
+	// compare field template with object
+	CompareFieldTemplateAttr(ctx context.Context, header http.Header, option metadata.CompareFieldTmplAttrOption) (
+		*metadata.CompareFieldTmplAttrsResResp, errors.CCErrorCoder)
+	CompareFieldTemplateUnique(ctx context.Context, header http.Header, option metadata.CompareFieldTmplUniqueOption) (
+		*metadata.CompareFieldTmplUniquesResResp, errors.CCErrorCoder)
+
+	ListFieldTemplateTasksStatus(ctx context.Context, header http.Header,
+		option metadata.ListFieldTmplTaskStatusOption) (
+		*metadata.ListFieldTmplTaskStatusResultResp, errors.CCErrorCoder)
+	ListFieldTemplateSyncStatus(ctx context.Context, header http.Header,
+		option metadata.ListFieldTmpltSyncStatusOption) (
+		*metadata.ListFieldTmpltSyncStatusResultResp, errors.CCErrorCoder)
+	ListFieldTmplByUniqueTmplIDForUI(ctx context.Context, header http.Header,
+		option metadata.ListTmplSimpleByUniqueOption) (*metadata.ListFieldTemplateSimpleResp, errors.CCErrorCoder)
+	ListFieldTmplByObjectTmplIDForUI(ctx context.Context, header http.Header,
+		option metadata.ListTmplSimpleByAttrOption) (*metadata.ListFieldTemplateSimpleResp, errors.CCErrorCoder)
+	ListFieldTemplateModelStatus(ctx context.Context, header http.Header,
+		option metadata.ListFieldTmplModelStatusOption) (*metadata.ListFieldTmplTaskSyncResultResp, errors.CCErrorCoder)
+}
+
+// NewFieldTemplateInterface TODO
+func NewFieldTemplateInterface(client rest.ClientInterface) FieldTemplateInterface {
+	return &FieldTemplate{client: client}
+}
+
+// FieldTemplate TODO
+type FieldTemplate struct {
+	client rest.ClientInterface
+}

--- a/src/apimachinery/toposerver/fieldtemplate/field_template.go
+++ b/src/apimachinery/toposerver/fieldtemplate/field_template.go
@@ -1,0 +1,625 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云 - 配置平台 (BlueKing - Configuration System) available.
+ * Copyright (C) 2017 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package fieldtemplate
+
+import (
+	"context"
+	"net/http"
+
+	"configcenter/src/common/errors"
+	"configcenter/src/common/metadata"
+)
+
+// ListFieldTemplate list field templates
+func (ft FieldTemplate) ListFieldTemplate(ctx context.Context, h http.Header, opt metadata.CommonQueryOption) (
+	*metadata.ListFieldTemplateResp, errors.CCErrorCoder) {
+
+	ret := new(metadata.ListFieldTemplateResp)
+	subPath := "/findmany/field_template"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(opt).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// CreateFieldTemplate create field template
+func (ft FieldTemplate) CreateFieldTemplate(ctx context.Context, header http.Header,
+	option metadata.CreateFieldTmplOption) (*metadata.CreateResult, errors.CCErrorCoder) {
+
+	ret := new(metadata.CreateResult)
+	subPath := "/create/field_template"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// FindFieldTemplateByID find field template by id
+func (ft FieldTemplate) FindFieldTemplateByID(ctx context.Context, header http.Header, fieldTemplateID int64) (
+	*metadata.FieldTemplateResp, errors.CCErrorCoder) {
+
+	ret := new(metadata.FieldTemplateResp)
+	subPath := "/find/field_template/%d"
+
+	err := ft.client.Get().
+		WithContext(ctx).
+		SubResourcef(subPath, fieldTemplateID).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// FieldTemplateBindObject field template bind object
+func (ft FieldTemplate) FieldTemplateBindObject(ctx context.Context, header http.Header,
+	option metadata.FieldTemplateBindObjOpt) (*metadata.Response, errors.CCErrorCoder) {
+
+	ret := new(metadata.Response)
+	subPath := "/update/field_template/bind/object"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// FieldTemplateUnbindObject field template unbind object
+func (ft FieldTemplate) FieldTemplateUnbindObject(ctx context.Context, header http.Header,
+	option metadata.FieldTemplateUnbindObjOpt) (*metadata.Response, errors.CCErrorCoder) {
+
+	ret := new(metadata.Response)
+	subPath := "/update/field_template/unbind/object"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// DeleteFieldTemplate delete field template
+func (ft FieldTemplate) DeleteFieldTemplate(ctx context.Context, header http.Header,
+	option metadata.DeleteFieldTmplOption) (*metadata.Response, errors.CCErrorCoder) {
+
+	ret := new(metadata.Response)
+	subPath := "/delete/field_template"
+
+	err := ft.client.Delete().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// CloneFieldTemplate clone field template
+func (ft FieldTemplate) CloneFieldTemplate(ctx context.Context, header http.Header,
+	option metadata.CloneFieldTmplOption) (*metadata.CreateResult, errors.CCErrorCoder) {
+
+	ret := new(metadata.CreateResult)
+	subPath := "/create/field_template/clone"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// UpdateFieldTemplate update field template
+func (ft FieldTemplate) UpdateFieldTemplate(ctx context.Context, header http.Header,
+	option metadata.UpdateFieldTmplOption) (*metadata.Response, errors.CCErrorCoder) {
+
+	ret := new(metadata.Response)
+	subPath := "/update/field_template"
+
+	err := ft.client.Put().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// UpdateFieldTemplateInfo update field template info
+func (ft FieldTemplate) UpdateFieldTemplateInfo(ctx context.Context, header http.Header,
+	option metadata.FieldTemplate) (*metadata.Response, errors.CCErrorCoder) {
+
+	ret := new(metadata.Response)
+	subPath := "/update/field_template/info"
+
+	err := ft.client.Put().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// ListFieldTemplateAttr list field template attributes
+func (ft FieldTemplate) ListFieldTemplateAttr(ctx context.Context, h http.Header,
+	opt metadata.ListFieldTmplAttrOption) (*metadata.ListFieldTemplateAttrResp, errors.CCErrorCoder) {
+
+	resp := new(metadata.ListFieldTemplateAttrResp)
+	subPath := "/findmany/field_template/attribute"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(opt).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := resp.CCError(); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// CountFieldTemplateAttr count field template attribute
+func (ft FieldTemplate) CountFieldTemplateAttr(ctx context.Context, header http.Header,
+	option metadata.CountFieldTmplResOption) (*metadata.CountFieldTemplateAttrResult, errors.CCErrorCoder) {
+
+	ret := new(metadata.CountFieldTemplateAttrResult)
+	subPath := "/findmany/field_template/attribute/count"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// ListFieldTemplateUnique list field template unique
+func (ft FieldTemplate) ListFieldTemplateUnique(ctx context.Context, header http.Header,
+	option metadata.ListFieldTmplUniqueOption) (*metadata.ListFieldTmplUniqueResp, errors.CCErrorCoder) {
+
+	ret := new(metadata.ListFieldTmplUniqueResp)
+	subPath := "/findmany/field_template/unique"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// SyncFieldTemplateInfoToObjects sync field template info to objects
+func (ft FieldTemplate) SyncFieldTemplateInfoToObjects(ctx context.Context, header http.Header,
+	option metadata.FieldTemplateSyncOption) (*metadata.Response, errors.CCErrorCoder) {
+
+	ret := new(metadata.Response)
+	subPath := "/update/topo/field_template/sync"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// ListObjFieldTmplRel list object and field template relation
+func (ft FieldTemplate) ListObjFieldTmplRel(ctx context.Context, header http.Header,
+	option metadata.ListObjFieldTmplRelOption) (*metadata.ListObjFieldTmplRelResp, errors.CCErrorCoder) {
+
+	ret := new(metadata.ListObjFieldTmplRelResp)
+	subPath := "/findmany/field_template/object/relation"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// ListFieldTmplByObj list field template by object
+func (ft FieldTemplate) ListFieldTmplByObj(ctx context.Context, header http.Header,
+	option metadata.ListFieldTmplByObjOption) (*metadata.ListFieldTemplateResp, errors.CCErrorCoder) {
+
+	ret := new(metadata.ListFieldTemplateResp)
+	subPath := "/findmany/field_template/by_object"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// ListObjByFieldTmpl list object by field template
+func (ft FieldTemplate) ListObjByFieldTmpl(ctx context.Context, header http.Header,
+	option metadata.ListObjByFieldTmplOption) (*metadata.ReadModelResult, errors.CCErrorCoder) {
+
+	ret := new(metadata.ReadModelResult)
+	subPath := "/findmany/object/by_field_template"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// SyncFieldTemplateToObjectTask sync field template to object task
+func (ft FieldTemplate) SyncFieldTemplateToObjectTask(ctx context.Context, header http.Header,
+	option metadata.SyncObjectTask) (*metadata.Response, errors.CCErrorCoder) {
+
+	ret := new(metadata.Response)
+	subPath := "/sync/field_template/object/task"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// CompareFieldTemplateAttr compare field template attribute
+func (ft FieldTemplate) CompareFieldTemplateAttr(ctx context.Context, header http.Header,
+	option metadata.CompareFieldTmplAttrOption) (*metadata.CompareFieldTmplAttrsResResp, errors.CCErrorCoder) {
+
+	ret := new(metadata.CompareFieldTmplAttrsResResp)
+	subPath := "/find/field_template/attribute/difference"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// CompareFieldTemplateUnique compare field template unique
+func (ft FieldTemplate) CompareFieldTemplateUnique(ctx context.Context, header http.Header,
+	option metadata.CompareFieldTmplUniqueOption) (*metadata.CompareFieldTmplUniquesResResp, errors.CCErrorCoder) {
+
+	ret := new(metadata.CompareFieldTmplUniquesResResp)
+	subPath := "/find/field_template/unique/difference"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// ListFieldTemplateTasksStatus list field template task status
+func (ft FieldTemplate) ListFieldTemplateTasksStatus(ctx context.Context, header http.Header,
+	option metadata.ListFieldTmplTaskStatusOption) (*metadata.ListFieldTmplTaskStatusResultResp, errors.CCErrorCoder) {
+
+	ret := new(metadata.ListFieldTmplTaskStatusResultResp)
+	subPath := "/find/field_template/tasks_status"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// ListFieldTemplateSyncStatus list field template sync status
+func (ft FieldTemplate) ListFieldTemplateSyncStatus(ctx context.Context, header http.Header,
+	option metadata.ListFieldTmpltSyncStatusOption) (*metadata.ListFieldTmpltSyncStatusResultResp, errors.CCErrorCoder) {
+
+	ret := new(metadata.ListFieldTmpltSyncStatusResultResp)
+	subPath := "/find/field_template/sync/status"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// ListFieldTmplByUniqueTmplIDForUI list field template by unique template for ui
+func (ft FieldTemplate) ListFieldTmplByUniqueTmplIDForUI(ctx context.Context, header http.Header,
+	option metadata.ListTmplSimpleByUniqueOption) (*metadata.ListFieldTemplateSimpleResp, errors.CCErrorCoder) {
+
+	ret := new(metadata.ListFieldTemplateSimpleResp)
+	subPath := "/find/field_template/simplify/by_unique_template_id"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// ListFieldTmplByObjectTmplIDForUI list field template by attribute template for ui
+func (ft FieldTemplate) ListFieldTmplByObjectTmplIDForUI(ctx context.Context, header http.Header,
+	option metadata.ListTmplSimpleByAttrOption) (*metadata.ListFieldTemplateSimpleResp, errors.CCErrorCoder) {
+
+	ret := new(metadata.ListFieldTemplateSimpleResp)
+	subPath := "/find/field_template/simplify/by_attr_template_id"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// ListFieldTemplateModelStatus list field template model status
+func (ft FieldTemplate) ListFieldTemplateModelStatus(ctx context.Context, header http.Header,
+	option metadata.ListFieldTmplModelStatusOption) (*metadata.ListFieldTmplTaskSyncResultResp, errors.CCErrorCoder) {
+
+	ret := new(metadata.ListFieldTmplTaskSyncResultResp)
+	subPath := "/find/field_template/model/status"
+
+	err := ft.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(header).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		return nil, errors.CCHttpError
+	}
+	if err := ret.CCError(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}

--- a/src/apimachinery/toposerver/object/api.go
+++ b/src/apimachinery/toposerver/object/api.go
@@ -28,7 +28,8 @@ type ObjectInterface interface {
 	SelectModelByClsID(ctx context.Context, ownerID string, clsID string, objID string, h http.Header) (
 		resp *metadata.Response, err error)
 	SelectInst(ctx context.Context, bizID int64, h http.Header) (resp *metadata.Response, err error)
-	CreateObjectAtt(ctx context.Context, h http.Header, obj *metadata.ObjAttDes) (resp *metadata.Response, err error)
+	CreateObjectAtt(ctx context.Context, h http.Header, obj *metadata.ObjAttDes) (
+		resp *metadata.CreateObjAttDesResp, err error)
 	SelectObjectAttWithParams(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response,
 		err error)
 	UpdateObjectAtt(ctx context.Context, objID string, h http.Header, data map[string]interface{}) (

--- a/src/apimachinery/toposerver/object/attribute.go
+++ b/src/apimachinery/toposerver/object/attribute.go
@@ -19,10 +19,10 @@ import (
 	"configcenter/src/common/metadata"
 )
 
-// CreateObjectAtt TODO
-func (t *object) CreateObjectAtt(ctx context.Context, h http.Header, obj *metadata.ObjAttDes) (resp *metadata.Response,
+// CreateObjectAtt create object attribute
+func (t *object) CreateObjectAtt(ctx context.Context, h http.Header, obj *metadata.ObjAttDes) (resp *metadata.CreateObjAttDesResp,
 	err error) {
-	resp = new(metadata.Response)
+	resp = new(metadata.CreateObjAttDesResp)
 	subPath := "/create/objectattr"
 
 	err = t.client.Post().

--- a/src/apimachinery/toposerver/toposerver.go
+++ b/src/apimachinery/toposerver/toposerver.go
@@ -18,6 +18,7 @@ import (
 
 	"configcenter/src/apimachinery/rest"
 	"configcenter/src/apimachinery/toposerver/association"
+	"configcenter/src/apimachinery/toposerver/fieldtemplate"
 	"configcenter/src/apimachinery/toposerver/inst"
 	"configcenter/src/apimachinery/toposerver/kube"
 	"configcenter/src/apimachinery/toposerver/object"
@@ -34,6 +35,7 @@ type TopoServerClientInterface interface {
 	SetTemplate() settemplate.SetTemplateInterface
 	ResourceDirectory() resourcedir.ResourceDirectoryInterface
 	Kube() kube.KubeOperationInterface
+	FieldTemplate() fieldtemplate.FieldTemplateInterface
 }
 
 // NewTopoServerClient TODO
@@ -76,4 +78,9 @@ func (t *topoServer) SetTemplate() settemplate.SetTemplateInterface {
 // ResourceDirectory TODO
 func (t *topoServer) ResourceDirectory() resourcedir.ResourceDirectoryInterface {
 	return resourcedir.NewResourceDirectoryInterface(t.restCli)
+}
+
+// FieldTemplate TODO
+func (t *topoServer) FieldTemplate() fieldtemplate.FieldTemplateInterface {
+	return fieldtemplate.NewFieldTemplateInterface(t.restCli)
 }

--- a/src/common/metadata/attribute.go
+++ b/src/common/metadata/attribute.go
@@ -161,6 +161,12 @@ type ObjAttDes struct {
 	PropertyGroupName string `json:"bk_property_group_name"`
 }
 
+// CreateObjAttDesResp 创建对象模型属性返回结构体
+type CreateObjAttDesResp struct {
+	BaseResp `json:",inline"`
+	Data     ObjAttDes `json:"data"`
+}
+
 // HostObjAttDes TODO
 type HostObjAttDes struct {
 	ObjAttDes        `json:",inline" bson:",inline"`

--- a/src/common/metadata/field_template.go
+++ b/src/common/metadata/field_template.go
@@ -39,6 +39,12 @@ type FieldTemplate struct {
 	LastTime    *Time  `json:"last_time" bson:"last_time"`
 }
 
+// FieldTemplateResp find field template response
+type FieldTemplateResp struct {
+	BaseResp `json:",inline"`
+	Data     FieldTemplate `json:"data"`
+}
+
 const (
 	// fieldTemplateSyncMaxNum compare the difference status between the
 	// template and the model The maximum number of models processed at one time
@@ -672,6 +678,12 @@ type CompareFieldTmplAttrsRes struct {
 	Unchanged []Attribute                  `json:"unchanged"`
 }
 
+// CompareFieldTmplAttrsResResp compare field template attributes with object result response
+type CompareFieldTmplAttrsResResp struct {
+	BaseResp `json:",inline"`
+	Data     CompareFieldTmplAttrsRes `json:"data"`
+}
+
 // CompareOneFieldTmplAttrRes compare one field template attribute with object result
 type CompareOneFieldTmplAttrRes struct {
 	// Index field template's original index in input attribute array
@@ -728,6 +740,12 @@ type CompareFieldTmplUniquesRes struct {
 	Update    []CompareOneFieldTmplUniqueRes `json:"update"`
 	Conflict  []CompareOneFieldTmplUniqueRes `json:"conflict"`
 	Unchanged []ObjectUnique                 `json:"unchanged"`
+}
+
+// CompareFieldTmplUniquesResResp compare field template uniques with object result response
+type CompareFieldTmplUniquesResResp struct {
+	BaseResp `json:",inline"`
+	Data     CompareFieldTmplUniquesRes `json:"data"`
 }
 
 // CompareOneFieldTmplUniqueRes compare one field template unique with object result
@@ -913,6 +931,12 @@ func (option *ListFieldTmpltSyncStatusOption) Validate() ccErr.RawErrorInfo {
 type ListFieldTmpltSyncStatusResult struct {
 	ObjectID int64 `json:"object_id"`
 	NeedSync bool  `json:"need_sync"`
+}
+
+// ListFieldTmpltSyncStatusResultResp list field template sync status result response
+type ListFieldTmpltSyncStatusResultResp struct {
+	BaseResp `json:",inline"`
+	Data     []ListFieldTmpltSyncStatusResult `json:"data"`
 }
 
 // ListFieldTmplModelStatusOption list field template model status option

--- a/src/common/metadata/taskserver.go
+++ b/src/common/metadata/taskserver.go
@@ -267,6 +267,12 @@ type ListFieldTmplTaskStatusResult struct {
 	Status string `json:"status"`
 }
 
+// ListFieldTmplTaskStatusResultResp list task status of the template ID and object response
+type ListFieldTmplTaskStatusResultResp struct {
+	BaseResp
+	Data []ListFieldTmplTaskStatusResult `json:"data"`
+}
+
 // ListFieldTmplTaskSyncResultResp list field template task sync result response
 type ListFieldTmplTaskSyncResultResp struct {
 	BaseResp

--- a/src/common/metadata/webserver.go
+++ b/src/common/metadata/webserver.go
@@ -326,3 +326,9 @@ type FieldTmplResCount struct {
 	TemplateID int64 `json:"bk_template_id"`
 	Count      int   `json:"count"`
 }
+
+// CountFieldTemplateAttrResult count field template attr result
+type CountFieldTemplateAttrResult struct {
+	BaseResp `json:",inline"`
+	Data     []FieldTmplResCount `json:"data"`
+}

--- a/src/test/topo_server/field_template_test.go
+++ b/src/test/topo_server/field_template_test.go
@@ -1,0 +1,916 @@
+/*
+* Tencent is pleased to support the open source community by making
+* 蓝鲸智云 - 配置平台 (BlueKing - Configuration System) available.
+* Copyright (C) 2017 THL A29 Limited,
+* a Tencent company. All rights reserved.
+* Licensed under the MIT License (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at http://opensource.org/licenses/MIT
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on
+* an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+* either express or implied. See the License for the
+* specific language governing permissions and limitations under the License.
+* We undertake not to change the open source license (MIT license) applicable
+* to the current version of the project delivered to anyone in the future.
+ */
+
+package topo_server_test
+
+import (
+	"context"
+	"time"
+
+	"configcenter/src/common"
+	"configcenter/src/common/json"
+	"configcenter/src/common/metadata"
+	"configcenter/src/test/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+var (
+	// 字段组合模板id
+	fieldTemplateID, fieldTemplateID1, fieldTemplateID2 int64
+	// 克隆的字段组合模板id
+	cloneFieldTmplID int64
+	// 字段组合模板属性字段数组
+	fieldTmplAttrArr []metadata.FieldTemplateAttr
+	// 字段组合模板唯一校验数组
+	fieldTmplUniqueArr []metadata.FieldTemplateUnique
+	// 字段组合模板测试模型
+	fieldTmplObject, fieldTmplObject1, fieldTmplObject2 metadata.Object
+	// 字段组合模板同步信息到模型的任务id
+	taskID, failureTaskID string
+	// 模型唯一校验信息
+	objUnique metadata.ObjectUnique
+	// 模型属性字段信息
+	objAttr metadata.Attribute
+)
+
+var _ = Describe("field template test", func() {
+	ctx := context.Background()
+
+	It("normal field template test", func() {
+		By("create field template")
+		func() {
+			option := metadata.CreateFieldTmplOption{
+				FieldTemplate: metadata.FieldTemplate{
+					Name:        "my_tmp",
+					Description: "my_tmp",
+				},
+				Attributes: []metadata.FieldTemplateAttr{
+					{
+						PropertyID:   "prop",
+						PropertyName: "prop",
+						PropertyType: "int",
+						Option: map[string]interface{}{
+							"min": 1,
+							"max": 1000,
+						},
+						Default: 500,
+					},
+				},
+				Uniques: []metadata.FieldTmplUniqueOption{{
+					Keys: []string{"prop"},
+				}},
+			}
+			rsp, err := fieldTemplateClient.CreateFieldTemplate(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
+				"Result": Equal(true),
+			}))
+			Expect(rsp.Data.ID).To(Not(Equal(int64(0))))
+			fieldTemplateID = rsp.Data.ID
+		}()
+
+		By("create field template 'my_tmp1'")
+		func() {
+			option := metadata.CreateFieldTmplOption{
+				FieldTemplate: metadata.FieldTemplate{
+					Name:        "my_tmp1",
+					Description: "my_tmp1",
+				},
+				Attributes: []metadata.FieldTemplateAttr{
+					{
+						PropertyID:   "prop1",
+						PropertyName: "prop1",
+						PropertyType: "singlechar",
+						Option:       "",
+						Default:      "aaa",
+					},
+				},
+				Uniques: []metadata.FieldTmplUniqueOption{{
+					Keys: []string{"prop1"},
+				}},
+			}
+			rsp, err := fieldTemplateClient.CreateFieldTemplate(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
+				"Result": Equal(true),
+			}))
+			Expect(rsp.Data.ID).To(Not(Equal(int64(0))))
+			fieldTemplateID1 = rsp.Data.ID
+		}()
+
+		By("create field template 'my_tmp2'")
+		func() {
+			option := metadata.CreateFieldTmplOption{
+				FieldTemplate: metadata.FieldTemplate{
+					Name:        "my_tmp2",
+					Description: "my_tmp2",
+				},
+				Attributes: []metadata.FieldTemplateAttr{
+					{
+						PropertyID:   "prop2",
+						PropertyName: "prop2",
+						PropertyType: "enummulti",
+						Option: []map[string]interface{}{
+							{
+								"id":         "1",
+								"is_default": true,
+								"name":       "aaa",
+								"type":       "text",
+							},
+							{
+								"id":         "2",
+								"is_default": false,
+								"name":       "bbb",
+								"type":       "text",
+							},
+							{
+								"id":         "3",
+								"is_default": false,
+								"name":       "ccc",
+								"type":       "text",
+							},
+						},
+					},
+				},
+			}
+			rsp, err := fieldTemplateClient.CreateFieldTemplate(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
+				"Result": Equal(true),
+			}))
+			Expect(rsp.Data.ID).To(Not(Equal(int64(0))))
+			fieldTemplateID2 = rsp.Data.ID
+		}()
+
+		By("find field template by id")
+		func() {
+			rsp, err := fieldTemplateClient.FindFieldTemplateByID(ctx, header, fieldTemplateID)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
+				"Result": Equal(true),
+			}))
+			Expect(rsp.Data.ID).To(Equal(fieldTemplateID))
+			Expect(rsp.Data.Name).To(Equal("my_tmp"))
+		}()
+
+		By("list field template")
+		func() {
+			option := metadata.CommonQueryOption{
+				Page: metadata.BasePage{
+					Limit: 100,
+				},
+			}
+			rsp, err := fieldTemplateClient.ListFieldTemplate(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rsp.Data.Info[0].ID).Should(BeElementOf(fieldTemplateID, fieldTemplateID1, fieldTemplateID2))
+			Expect(rsp.Data.Info[0].Name).Should(BeElementOf("my_tmp", "my_tmp1", "my_tmp2"))
+			Expect(rsp.Data.Info[0].Description).Should(BeElementOf("my_tmp", "my_tmp1", "my_tmp2"))
+		}()
+
+		By("again create field template 'my_tmp'")
+		func() {
+			option := metadata.CreateFieldTmplOption{
+				FieldTemplate: metadata.FieldTemplate{
+					Name:        "my_tmp",
+					Description: "my_tmp",
+				},
+				Attributes: []metadata.FieldTemplateAttr{
+					{
+						PropertyID:   "prop",
+						PropertyName: "prop",
+						PropertyType: "int",
+						Option: map[string]interface{}{
+							"min": 1,
+							"max": 1000,
+						},
+						Default: 500,
+					},
+				},
+				Uniques: []metadata.FieldTmplUniqueOption{{
+					Keys: []string{"prop"},
+				}},
+			}
+			rsp, err := fieldTemplateClient.CreateFieldTemplate(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).To(HaveOccurred())
+		}()
+
+		By("create field template duplicate property")
+		func() {
+			option := metadata.CreateFieldTmplOption{
+				FieldTemplate: metadata.FieldTemplate{
+					Name:        "field_tmp_test",
+					Description: "field_tmp_test",
+				},
+				Attributes: []metadata.FieldTemplateAttr{
+					{
+						PropertyID:   "prop_test",
+						PropertyName: "prop_test",
+						PropertyType: "int",
+						Option: map[string]interface{}{
+							"min": 1,
+							"max": 1000,
+						},
+						Default: 500,
+					},
+					{
+						PropertyID:   "prop_test",
+						PropertyName: "prop_test",
+						PropertyType: "int",
+						Option: map[string]interface{}{
+							"min": 1,
+							"max": 1000,
+						},
+						Default: 500,
+					},
+				},
+				Uniques: []metadata.FieldTmplUniqueOption{{
+					Keys: []string{"prop_test"},
+				}},
+			}
+			rsp, err := fieldTemplateClient.CreateFieldTemplate(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).To(HaveOccurred())
+		}()
+
+		By("create field template no attributes")
+		func() {
+			option := metadata.CreateFieldTmplOption{
+				FieldTemplate: metadata.FieldTemplate{
+					Name:        "field_tmp_test",
+					Description: "field_tmp_test",
+				},
+			}
+			rsp, err := fieldTemplateClient.CreateFieldTemplate(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).To(HaveOccurred())
+		}()
+
+		By("update field template info")
+		func() {
+			option := metadata.FieldTemplate{
+				ID:          fieldTemplateID,
+				Name:        "my_tmp_updated",
+				Description: "my_tmp_updated",
+			}
+			rsp, err := fieldTemplateClient.UpdateFieldTemplateInfo(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
+				"Result": Equal(true),
+			}))
+		}()
+
+		By("find field template by id after the update")
+		func() {
+			rsp, err := fieldTemplateClient.FindFieldTemplateByID(ctx, header, fieldTemplateID)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
+				"Result": Equal(true),
+			}))
+			Expect(rsp.Data.ID).To(Equal(fieldTemplateID))
+			Expect(rsp.Data.Name).To(Equal("my_tmp_updated"))
+			Expect(rsp.Data.Description).To(Equal("my_tmp_updated"))
+		}()
+
+		By("update field template unsupported type")
+		func() {
+			option := metadata.UpdateFieldTmplOption{
+				FieldTemplate: metadata.FieldTemplate{
+					ID:   fieldTemplateID,
+					Name: "my_tmp",
+				},
+				Attributes: []metadata.FieldTemplateAttr{
+					{
+						PropertyID:   "prop",
+						PropertyName: "prop",
+						PropertyType: "int",
+						Option: map[string]interface{}{
+							"min": 1,
+							"max": 1000,
+						},
+						Default: 600,
+					},
+					{
+						PropertyID:   "prop2",
+						PropertyName: "prop2",
+						PropertyType: "innertable",
+						Option:       "",
+						Default:      "",
+					},
+				},
+				Uniques: []metadata.FieldTmplUniqueOption{
+					{
+						Keys: []string{"prop2"},
+					},
+				},
+			}
+			rsp, err := fieldTemplateClient.UpdateFieldTemplate(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).To(HaveOccurred())
+		}()
+
+		By("update field template")
+		func() {
+			option := metadata.UpdateFieldTmplOption{
+				FieldTemplate: metadata.FieldTemplate{
+					ID:   fieldTemplateID,
+					Name: "my_tmp",
+				},
+				Attributes: []metadata.FieldTemplateAttr{
+					{
+						PropertyID:   "prop",
+						PropertyName: "prop",
+						PropertyType: "int",
+						Option: map[string]interface{}{
+							"min": 1,
+							"max": 1000,
+						},
+						Default: 600,
+					},
+					{
+						PropertyID:   "prop2",
+						PropertyName: "prop2",
+						PropertyType: "singlechar",
+						Option:       "",
+						Default:      "test",
+					},
+				},
+				Uniques: []metadata.FieldTmplUniqueOption{
+					{
+						Keys: []string{"prop2"},
+					},
+				},
+			}
+			rsp, err := fieldTemplateClient.UpdateFieldTemplate(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
+				"Result": Equal(true),
+			}))
+		}()
+
+		By("count field template attribute")
+		func() {
+			option := metadata.CountFieldTmplResOption{
+				TemplateIDs: []int64{fieldTemplateID},
+			}
+			rsp, err := fieldTemplateClient.CountFieldTemplateAttr(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rsp.Data[0].TemplateID).To(Equal(fieldTemplateID))
+			Expect(rsp.Data[0].Count).To(Equal(2))
+		}()
+
+		By("list field template attribute")
+		func() {
+			option := metadata.ListFieldTmplAttrOption{
+				TemplateID: fieldTemplateID,
+			}
+			rsp, err := fieldTemplateClient.ListFieldTemplateAttr(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rsp.Data.Info).NotTo(BeEmpty())
+			fieldTmplAttrArr = rsp.Data.Info
+		}()
+
+		By("list field template unique")
+		func() {
+			option := metadata.ListFieldTmplUniqueOption{
+				TemplateID: fieldTemplateID,
+			}
+			rsp, err := fieldTemplateClient.ListFieldTemplateUnique(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rsp.Data.Info).NotTo(BeNil())
+			fieldTmplUniqueArr = rsp.Data.Info
+		}()
+
+		By("clone field template")
+		func() {
+			option := metadata.CloneFieldTmplOption{
+				ID: fieldTemplateID,
+				FieldTemplate: metadata.FieldTemplate{
+					Name:        "my_tmp-copy",
+					Description: "my_tmp-copy",
+				},
+			}
+			rsp, err := fieldTemplateClient.CloneFieldTemplate(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rsp.Data.ID).NotTo(Equal(0))
+			cloneFieldTmplID = rsp.Data.ID
+		}()
+
+		By("delete field template")
+		func() {
+			option := metadata.DeleteFieldTmplOption{
+				ID: cloneFieldTmplID,
+			}
+			rsp, err := fieldTemplateClient.DeleteFieldTemplate(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).To(BeNil())
+		}()
+
+		By("find field template by id")
+		func() {
+			rsp, err := fieldTemplateClient.FindFieldTemplateByID(ctx, header, cloneFieldTmplID)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
+				"Result": Equal(true),
+			}))
+			Expect(rsp.Data.ID).To(Equal(int64(0)))
+		}()
+
+		By("create object classification")
+		func() {
+			option := metadata.Classification{
+				ClassificationID:   "field_tmpl_test_class",
+				ClassificationName: "字段组合模板测试模型分组",
+			}
+			rsp, err := objectClient.CreateClassification(ctx, header, &option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+		}()
+
+		By("create object")
+		func() {
+			option := metadata.Object{
+				ObjCls:     "field_tmpl_test_class",
+				ObjectID:   "field_tmpl_test_obj",
+				ObjectName: "字段组合模板测试模型",
+				ObjIcon:    "icon-cc-default",
+				OwnerID:    "0",
+				Creator:    "admin",
+			}
+			rsp, err := objectClient.CreateObject(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			Expect(rsp.Data.ObjCls).To(Equal(option.ObjCls))
+			Expect(rsp.Data.ObjectID).To(Equal(option.ObjectID))
+			Expect(rsp.Data.ObjectName).To(Equal(option.ObjectName))
+			Expect(rsp.Data.OwnerID).To(Equal(option.OwnerID))
+			Expect(rsp.Data.Creator).To(Equal(option.Creator))
+			fieldTmplObject = rsp.Data
+		}()
+
+		By("create object 'field_tmpl_test_obj1'")
+		func() {
+			option := metadata.Object{
+				ObjCls:     "field_tmpl_test_class",
+				ObjectID:   "field_tmpl_test_obj1",
+				ObjectName: "字段组合模板测试模型1",
+				ObjIcon:    "icon-cc-default",
+				OwnerID:    "0",
+				Creator:    "admin",
+			}
+			rsp, err := objectClient.CreateObject(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			Expect(rsp.Data.ObjCls).To(Equal(option.ObjCls))
+			Expect(rsp.Data.ObjectID).To(Equal(option.ObjectID))
+			Expect(rsp.Data.ObjectName).To(Equal(option.ObjectName))
+			Expect(rsp.Data.OwnerID).To(Equal(option.OwnerID))
+			Expect(rsp.Data.Creator).To(Equal(option.Creator))
+			fieldTmplObject1 = rsp.Data
+		}()
+
+		By("create object 'field_tmpl_test_obj2'")
+		func() {
+			option := metadata.Object{
+				ObjCls:     "field_tmpl_test_class",
+				ObjectID:   "field_tmpl_test_obj2",
+				ObjectName: "字段组合模板测试模型2",
+				ObjIcon:    "icon-cc-default",
+				OwnerID:    "0",
+				Creator:    "admin",
+			}
+			rsp, err := objectClient.CreateObject(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			Expect(rsp.Data.ObjCls).To(Equal(option.ObjCls))
+			Expect(rsp.Data.ObjectID).To(Equal(option.ObjectID))
+			Expect(rsp.Data.ObjectName).To(Equal(option.ObjectName))
+			Expect(rsp.Data.OwnerID).To(Equal(option.OwnerID))
+			Expect(rsp.Data.Creator).To(Equal(option.Creator))
+			fieldTmplObject2 = rsp.Data
+		}()
+
+		By("field template bind object")
+		func() {
+			option := metadata.FieldTemplateBindObjOpt{
+				ID:        fieldTemplateID,
+				ObjectIDs: []int64{fieldTmplObject.ID, fieldTmplObject1.ID, fieldTmplObject2.ID},
+			}
+			rsp, err := fieldTemplateClient.FieldTemplateBindObject(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
+				"Result": Equal(true),
+			}))
+			Expect(rsp.Data).To(BeNil())
+		}()
+
+		By("field template 'fieldTemplateID2' bind object 'fieldTmplObject2'")
+		func() {
+			option := metadata.FieldTemplateBindObjOpt{
+				ID:        fieldTemplateID2,
+				ObjectIDs: []int64{fieldTmplObject2.ID},
+			}
+			rsp, err := fieldTemplateClient.FieldTemplateBindObject(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
+				"Result": Equal(true),
+			}))
+			Expect(rsp.Data).To(BeNil())
+		}()
+
+		By("list object and field template relationship")
+		func() {
+			option := metadata.ListObjFieldTmplRelOption{
+				TemplateIDs: []int64{fieldTemplateID},
+				ObjectIDs:   []int64{fieldTmplObject.ID},
+			}
+			rsp, err := fieldTemplateClient.ListObjFieldTmplRel(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			Expect(rsp.Data.Info[0].ObjectID).Should(BeElementOf(fieldTmplObject.ID, fieldTmplObject1.ID,
+				fieldTmplObject2.ID))
+			Expect(rsp.Data.Info[0].TemplateID).To(Equal(fieldTemplateID))
+		}()
+
+		By("list field template by object")
+		func() {
+			option := metadata.ListFieldTmplByObjOption{
+				ObjectID: fieldTmplObject2.ID,
+			}
+			rsp, err := fieldTemplateClient.ListFieldTmplByObj(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			Expect(rsp.Data.Info[0].ID).Should(BeElementOf(fieldTemplateID, fieldTemplateID2))
+		}()
+
+		By("list object by field template")
+		func() {
+			option := metadata.ListObjByFieldTmplOption{
+				TemplateID: fieldTemplateID,
+				CommonQueryOption: metadata.CommonQueryOption{
+					Page: metadata.BasePage{Limit: 100},
+				},
+			}
+			rsp, err := fieldTemplateClient.ListObjByFieldTmpl(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			Expect(rsp.Data.Info[0].ID).Should(BeElementOf(fieldTmplObject.ID, fieldTmplObject1.ID,
+				fieldTmplObject2.ID))
+		}()
+
+		By("sync field template info to object")
+		func() {
+			option := metadata.FieldTemplateSyncOption{
+				TemplateID: fieldTemplateID,
+				ObjectIDs:  []int64{fieldTmplObject.ID, fieldTmplObject2.ID},
+			}
+			rsp, err := fieldTemplateClient.SyncFieldTemplateInfoToObjects(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			data := rsp.Data.([]interface{})
+			taskID = data[0].(string)
+		}()
+
+		By("list field template tasks status")
+		func() {
+			for {
+				option := metadata.ListFieldTmplTaskStatusOption{
+					TaskIDs: []string{taskID},
+				}
+				rsp, err := fieldTemplateClient.ListFieldTemplateTasksStatus(ctx, header, option)
+				util.RegisterResponseWithRid(rsp, header)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(rsp.Result).To(Equal(true))
+				Expect(rsp.Data[0].TaskID).To(Equal(taskID))
+				if rsp.Data[0].Status == "finished" {
+					break
+				}
+				time.Sleep(3 * time.Second)
+			}
+		}()
+
+		By("list field template sync status")
+		func() {
+			option := metadata.ListFieldTmpltSyncStatusOption{
+				ID:        fieldTemplateID,
+				ObjectIDs: []int64{fieldTmplObject.ID},
+			}
+			rsp, err := fieldTemplateClient.ListFieldTemplateSyncStatus(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			Expect(rsp.Data[0].ObjectID).To(Equal(fieldTmplObject.ID))
+			Expect(rsp.Data[0].NeedSync).To(Equal(false))
+		}()
+
+		By("update field template")
+		func() {
+			option := metadata.UpdateFieldTmplOption{
+				FieldTemplate: metadata.FieldTemplate{
+					ID:   fieldTemplateID2,
+					Name: "my_tmp2",
+				},
+				Attributes: []metadata.FieldTemplateAttr{
+					{
+						PropertyID:   "prop2",
+						PropertyName: "prop2",
+						PropertyType: "enummulti",
+						Option: []map[string]interface{}{
+							{
+								"id":         "1",
+								"is_default": true,
+								"name":       "aaa",
+								"type":       "text",
+							},
+							{
+								"id":         "2",
+								"is_default": false,
+								"name":       "bbb",
+								"type":       "text",
+							},
+							{
+								"id":         "3",
+								"is_default": false,
+								"name":       "ccc",
+								"type":       "text",
+							},
+						},
+					},
+					{
+						PropertyID:   "prop3",
+						PropertyName: "prop3",
+						PropertyType: "singlechar",
+						Option:       "",
+						Default:      "test",
+					},
+					{
+						PropertyID:   "prop4",
+						PropertyName: "prop4",
+						PropertyType: "singlechar",
+						Option:       "",
+						Default:      "test",
+					},
+				},
+				Uniques: []metadata.FieldTmplUniqueOption{
+					{
+						Keys: []string{"prop3"},
+					},
+				},
+			}
+			rsp, err := fieldTemplateClient.UpdateFieldTemplate(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rsp.BaseResp).To(MatchFields(IgnoreExtras, Fields{
+				"Result": Equal(true),
+			}))
+		}()
+
+		By("compare object attribute and field template attribute")
+		func() {
+			option := metadata.CompareFieldTmplAttrOption{
+				TemplateID: fieldTemplateID2,
+				ObjectID:   fieldTmplObject2.ID,
+				Attrs: []metadata.FieldTemplateAttr{
+					{
+						PropertyID:   "prop2",
+						PropertyName: "prop2",
+						PropertyType: "enummulti",
+						Option: []map[string]interface{}{
+							{
+								"id":         "1",
+								"is_default": true,
+								"name":       "aaa",
+								"type":       "text",
+							},
+							{
+								"id":         "2",
+								"is_default": false,
+								"name":       "bbb",
+								"type":       "text",
+							},
+							{
+								"id":         "3",
+								"is_default": false,
+								"name":       "ccc",
+								"type":       "text",
+							},
+						},
+					},
+					{
+						PropertyID:   "prop3",
+						PropertyName: "prop3",
+						PropertyType: "singlechar",
+						Option:       "",
+						Default:      "test",
+					},
+					{
+						PropertyID:   "prop4",
+						PropertyName: "prop4",
+						PropertyType: "singlechar",
+						Option:       "",
+						Default:      "test",
+					},
+				},
+			}
+			rsp, err := fieldTemplateClient.CompareFieldTemplateAttr(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			Expect(rsp.Data).NotTo(BeNil())
+			Expect(rsp.Data.Create[0].PropertyID).Should(BeElementOf("prop3", "prop4"))
+			Expect(rsp.Data.Conflict[0].PropertyID).Should(BeElementOf("prop2"))
+			Expect(rsp.Data.Unchanged[0].PropertyID).Should(BeElementOf("prop", "bk_inst_name"))
+		}()
+
+		By("compare object unique and field template unique")
+		func() {
+			option := metadata.CompareFieldTmplUniqueOption{
+				TemplateID: fieldTemplateID,
+				ObjectID:   fieldTmplObject.ID,
+				Uniques: []metadata.FieldTmplUniqueForUpdate{
+					{
+						Keys: []string{"prop3"},
+					},
+				},
+			}
+			rsp, err := fieldTemplateClient.CompareFieldTemplateUnique(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			Expect(rsp.Data).NotTo(BeNil())
+			Expect(rsp.Data.Create[0].Index).To(Equal(0))
+		}()
+
+		By("list field template sync status")
+		func() {
+			option := metadata.ListFieldTmpltSyncStatusOption{
+				ID:        fieldTemplateID2,
+				ObjectIDs: []int64{fieldTmplObject2.ID},
+			}
+			rsp, err := fieldTemplateClient.ListFieldTemplateSyncStatus(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			Expect(rsp.Data[0].ObjectID).To(Equal(fieldTmplObject2.ID))
+			Expect(rsp.Data[0].NeedSync).To(Equal(true))
+		}()
+
+		By("sync field template info to object failure")
+		func() {
+			option := metadata.FieldTemplateSyncOption{
+				TemplateID: fieldTemplateID2,
+				ObjectIDs:  []int64{fieldTmplObject2.ID},
+			}
+			rsp, err := fieldTemplateClient.SyncFieldTemplateInfoToObjects(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			data := rsp.Data.([]interface{})
+			failureTaskID = data[0].(string)
+		}()
+
+		By("list field template tasks status")
+		func() {
+			for {
+				option := metadata.ListFieldTmplTaskStatusOption{
+					TaskIDs: []string{failureTaskID},
+				}
+				rsp, err := fieldTemplateClient.ListFieldTemplateTasksStatus(ctx, header, option)
+				util.RegisterResponseWithRid(rsp, header)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(rsp.Result).To(Equal(true))
+				Expect(rsp.Data[0].TaskID).To(Equal(failureTaskID))
+				if rsp.Data[0].Status == "failure" {
+					break
+				}
+				time.Sleep(3 * time.Second)
+			}
+		}()
+
+		By("delete field template failure")
+		func() {
+			option := metadata.DeleteFieldTmplOption{
+				ID: fieldTemplateID2,
+			}
+			rsp, err := fieldTemplateClient.DeleteFieldTemplate(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).To(HaveOccurred())
+		}()
+
+		By("search object unique")
+		func() {
+			rsp, err := objectClient.SearchObjectUnique(ctx, fieldTmplObject.ObjectID, header)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			objUniqueArr := make([]metadata.ObjectUnique, 0)
+			rspData, err := json.Marshal(rsp.Data)
+			err = json.Unmarshal(rspData, &objUniqueArr)
+			Expect(err).ShouldNot(HaveOccurred())
+			for _, ou := range objUniqueArr {
+				if ou.TemplateID == 0 {
+					continue
+				}
+				objUnique = ou
+			}
+			Expect(objUnique.ObjID).To(Equal(fieldTmplObject.ObjectID))
+		}()
+
+		By("list field template simple data by unique option")
+		func() {
+			option := metadata.ListTmplSimpleByUniqueOption{
+				TemplateID: fieldTmplUniqueArr[0].ID,
+				UniqueID:   int64(objUnique.ID),
+			}
+			rsp, err := fieldTemplateClient.ListFieldTmplByUniqueTmplIDForUI(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			Expect(rsp.Data.ID).To(Equal(fieldTemplateID))
+		}()
+
+		By("search object attribute")
+		func() {
+			data := map[string]interface{}{
+				common.BKObjIDField:      fieldTmplObject.ObjectID,
+				common.BKPropertyIDField: fieldTmplAttrArr[0].PropertyID,
+			}
+			rsp, err := objectClient.SelectObjectAttWithParams(ctx, header, data)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			objAttrResp := make([]metadata.ObjAttDes, 0)
+			rspData, err := json.Marshal(rsp.Data)
+			err = json.Unmarshal(rspData, &objAttrResp)
+			Expect(err).ShouldNot(HaveOccurred())
+			objAttr = objAttrResp[0].Attribute
+			Expect(objAttr.ObjectID).To(Equal(fieldTmplObject.ObjectID))
+		}()
+
+		By("list field template simple data by object attribute option")
+		func() {
+			option := metadata.ListTmplSimpleByAttrOption{
+				TemplateID: fieldTmplAttrArr[0].ID,
+				AttrID:     objAttr.ID,
+			}
+			rsp, err := fieldTemplateClient.ListFieldTmplByObjectTmplIDForUI(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			Expect(rsp.Data.ID).To(Equal(fieldTemplateID))
+		}()
+
+		By("list field template simple data by object attribute option")
+		func() {
+			option := metadata.ListFieldTmplModelStatusOption{
+				ID:        fieldTemplateID,
+				ObjectIDs: []int64{fieldTmplObject.ID},
+			}
+			rsp, err := fieldTemplateClient.ListFieldTemplateModelStatus(ctx, header, option)
+			util.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			Expect(rsp.Info[0].ObjectID).To(Equal(fieldTmplObject.ID))
+		}()
+	})
+})

--- a/src/test/topo_server/model_quote_test.go
+++ b/src/test/topo_server/model_quote_test.go
@@ -1,0 +1,426 @@
+/*
+* Tencent is pleased to support the open source community by making
+* 蓝鲸智云 - 配置平台 (BlueKing - Configuration System) available.
+* Copyright (C) 2017 THL A29 Limited,
+* a Tencent company. All rights reserved.
+* Licensed under the MIT License (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at http://opensource.org/licenses/MIT
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on
+* an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+* either express or implied. See the License for the
+* specific language governing permissions and limitations under the License.
+* We undertake not to change the open source license (MIT license) applicable
+* to the current version of the project delivered to anyone in the future.
+ */
+
+package topo_server_test
+
+import (
+	"context"
+
+	"configcenter/src/common"
+	"configcenter/src/common/mapstr"
+	"configcenter/src/common/metadata"
+	"configcenter/src/common/util"
+	testutil "configcenter/src/test/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	// 模型引用类型测试模型
+	modelQuoteObj metadata.Object
+	// 引用类型字段
+	quoteProp metadata.Attribute
+	// 模型实例id
+	instanceID int64
+	// 引用类型实例id数组
+	quoteInstIDArr []uint64
+)
+
+var _ = Describe("model quote type test", func() {
+	ctx := context.Background()
+	It("model quote type test", func() {
+		By("create object classification")
+		func() {
+			option := metadata.Classification{
+				ClassificationID:   "model_quote_test_class",
+				ClassificationName: "模型引用类型测试模型分组",
+			}
+			rsp, err := objectClient.CreateClassification(ctx, header, &option)
+			testutil.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+		}()
+
+		By("create object")
+		func() {
+			option := metadata.Object{
+				ObjCls:     "model_quote_test_class",
+				ObjectID:   "model_quote_test_obj",
+				ObjectName: "模型引用类型测试模型",
+				ObjIcon:    "icon-cc-default",
+				OwnerID:    "0",
+				Creator:    "admin",
+			}
+			rsp, err := objectClient.CreateObject(ctx, header, option)
+			testutil.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			Expect(rsp.Data.ObjCls).To(Equal(option.ObjCls))
+			Expect(rsp.Data.ObjectID).To(Equal(option.ObjectID))
+			Expect(rsp.Data.ObjectName).To(Equal(option.ObjectName))
+			Expect(rsp.Data.OwnerID).To(Equal(option.OwnerID))
+			Expect(rsp.Data.Creator).To(Equal(option.Creator))
+			modelQuoteObj = rsp.Data
+		}()
+
+		By("create model attribute")
+		func() {
+			option := metadata.ObjAttDes{
+				Attribute: metadata.Attribute{
+					ObjectID:      modelQuoteObj.ObjectID,
+					OwnerID:       "0",
+					Creator:       "admin",
+					PropertyID:    "model_quote_prop",
+					PropertyName:  "model_quote_prop",
+					PropertyGroup: common.BKDefaultField,
+					Unit:          "",
+					Placeholder:   "",
+					IsEditable:    true,
+					IsRequired:    false,
+					PropertyType:  common.FieldTypeInnerTable,
+					Option: map[string]interface{}{
+						"header": []map[string]interface{}{
+							{
+								common.BKPropertyIDField:   "cc1",
+								common.BKPropertyNameField: "cc1",
+								common.BKPropertyTypeField: "int",
+								"unit":                     "",
+								"placeholder":              "",
+								"editable":                 true,
+								"isrequired":               false,
+								"ismultiple":               false,
+								"option": map[string]interface{}{
+									"min": 1,
+									"max": 1000,
+								},
+								"default": 500,
+							},
+							{
+								common.BKPropertyIDField:   "cc2",
+								common.BKPropertyNameField: "cc2",
+								common.BKPropertyTypeField: "singlechar",
+								"unit":                     "",
+								"placeholder":              "",
+								"editable":                 true,
+								"isrequired":               false,
+								"ismultiple":               false,
+								"option":                   "",
+								"default":                  "abc",
+							},
+						},
+					},
+				},
+			}
+			rsp, err := objectClient.CreateObjectAtt(ctx, header, &option)
+			testutil.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			quoteProp = rsp.Data.Attribute
+			Expect(quoteProp.ObjectID).To(Equal(modelQuoteObj.ObjectID))
+			Expect(quoteProp.PropertyID).To(Equal(option.PropertyID))
+			Expect(quoteProp.PropertyGroup).To(Equal(common.BKDefaultField))
+			Expect(quoteProp.PropertyType).To(Equal(common.FieldTypeInnerTable))
+			Expect(quoteProp.Option).NotTo(BeNil())
+		}()
+
+		By("create model attribute model no exist")
+		func() {
+			option := metadata.ObjAttDes{
+				Attribute: metadata.Attribute{
+					ObjectID:      "model_quote_test_obj_noexist",
+					OwnerID:       "0",
+					Creator:       "admin",
+					PropertyID:    "model_quote_prop",
+					PropertyName:  "model_quote_prop",
+					PropertyGroup: common.BKDefaultField,
+					Unit:          "",
+					Placeholder:   "",
+					IsEditable:    true,
+					IsRequired:    false,
+					PropertyType:  common.FieldTypeInnerTable,
+					Option: map[string]interface{}{
+						"header": []map[string]interface{}{
+							{
+								common.BKPropertyIDField:   "cc1",
+								common.BKPropertyNameField: "cc1",
+								common.BKPropertyTypeField: "int",
+								"unit":                     "",
+								"placeholder":              "",
+								"editable":                 true,
+								"isrequired":               false,
+								"ismultiple":               false,
+								"option": map[string]interface{}{
+									"min": 1,
+									"max": 1000,
+								},
+								"default": 500,
+							},
+						},
+					},
+				},
+			}
+			rsp, err := objectClient.CreateObjectAtt(ctx, header, &option)
+			Expect(err).NotTo(HaveOccurred())
+			testutil.RegisterResponseWithRid(rsp, header)
+			Expect(rsp.Code).To(Equal(common.CCErrCommParamsIsInvalid))
+		}()
+
+		By("create model attribute 'model_quote_prop' again")
+		func() {
+			option := metadata.ObjAttDes{
+				Attribute: metadata.Attribute{
+					ObjectID:      modelQuoteObj.ObjectID,
+					OwnerID:       "0",
+					Creator:       "admin",
+					PropertyID:    "model_quote_prop",
+					PropertyName:  "model_quote_prop",
+					PropertyGroup: common.BKDefaultField,
+					Unit:          "",
+					Placeholder:   "",
+					IsEditable:    true,
+					IsRequired:    false,
+					PropertyType:  common.FieldTypeInnerTable,
+					Option: map[string]interface{}{
+						"header": []map[string]interface{}{
+							{
+								common.BKPropertyIDField:   "cc1",
+								common.BKPropertyNameField: "cc1",
+								common.BKPropertyTypeField: "int",
+								"unit":                     "",
+								"placeholder":              "",
+								"editable":                 true,
+								"isrequired":               false,
+								"ismultiple":               false,
+								"option": map[string]interface{}{
+									"min": 1,
+									"max": 1000,
+								},
+								"default": 500,
+							},
+						},
+					},
+				},
+			}
+			rsp, err := objectClient.CreateObjectAtt(ctx, header, &option)
+			testutil.RegisterResponseWithRid(rsp, header)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rsp.Code).To(Equal(common.CCErrCommDuplicateItem))
+		}()
+
+		By("create object instance")
+		func() {
+			option := mapstr.MapStr{
+				"bk_inst_name": "obj_quote_test",
+			}
+			rsp, err := instClient.CreateInst(ctx, modelQuoteObj.ObjectID, header, option)
+			testutil.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			instID, idExist := rsp.Data.Get(common.BKInstIDField)
+			Expect(idExist).To(Equal(true))
+			instanceID, err = util.GetInt64ByInterface(instID)
+			Expect(err).ShouldNot(HaveOccurred())
+			instName, nameExist := rsp.Data.Get(common.BKInstNameField)
+			Expect(nameExist).To(Equal(true))
+			Expect(util.GetStrByInterface(instName)).To(Equal("obj_quote_test"))
+		}()
+
+		By("create model quote instance")
+		func() {
+			option := metadata.BatchCreateQuotedInstOption{
+				ObjID:      modelQuoteObj.ObjectID,
+				PropertyID: quoteProp.PropertyID,
+				Data: []mapstr.MapStr{
+					{
+						"cc1":        10,
+						"cc2":        "aaa",
+						"bk_inst_id": instanceID,
+					},
+					{
+						"cc1":        20,
+						"cc2":        "bbb",
+						"bk_inst_id": instanceID,
+					},
+				},
+			}
+			rsp, err := modelQuoteClient.BatchCreateQuotedInstance(ctx, header, &option)
+			testutil.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp).To(HaveLen(2))
+			quoteInstIDArr = rsp
+		}()
+
+		By("create model quote instance but model instance no exist")
+		func() {
+			option := metadata.BatchCreateQuotedInstOption{
+				ObjID:      modelQuoteObj.ObjectID,
+				PropertyID: quoteProp.PropertyID,
+				Data: []mapstr.MapStr{
+					{
+						"cc1":        10,
+						"cc2":        "aaa",
+						"bk_inst_id": instanceID + 3256,
+					},
+					{
+						"cc1":        20,
+						"cc2":        "bbb",
+						"bk_inst_id": instanceID + 3256,
+					},
+				},
+			}
+			rsp, err := modelQuoteClient.BatchCreateQuotedInstance(ctx, header, &option)
+			testutil.RegisterResponseWithRid(rsp, header)
+			Expect(err).To(HaveOccurred())
+		}()
+
+		By("create model quote instance but model property no exist")
+		func() {
+			option := metadata.BatchCreateQuotedInstOption{
+				ObjID:      modelQuoteObj.ObjectID,
+				PropertyID: "prop_no_exist",
+				Data: []mapstr.MapStr{
+					{
+						"cc1":        10,
+						"cc2":        "aaa",
+						"bk_inst_id": instanceID + 3256,
+					},
+					{
+						"cc1":        20,
+						"cc2":        "bbb",
+						"bk_inst_id": instanceID + 3256,
+					},
+				},
+			}
+			rsp, err := modelQuoteClient.BatchCreateQuotedInstance(ctx, header, &option)
+			testutil.RegisterResponseWithRid(rsp, header)
+			Expect(err).To(HaveOccurred())
+		}()
+
+		By("list model quote instance")
+		func() {
+			option := metadata.ListQuotedInstOption{
+				ObjID:      modelQuoteObj.ObjectID,
+				PropertyID: quoteProp.PropertyID,
+				CommonQueryOption: metadata.CommonQueryOption{
+					Page: metadata.BasePage{
+						Limit: 100,
+					},
+				},
+			}
+			rsp, err := modelQuoteClient.ListQuotedInstance(ctx, header, &option)
+			testutil.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Info).To(HaveLen(2))
+			for _, inst := range rsp.Info {
+				instID, _ := inst.Get(common.BKInstIDField)
+				instID64, err := util.GetInt64ByInterface(instID)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(instID64).To(Equal(instanceID))
+			}
+		}()
+
+		By("update model quote instance")
+		func() {
+			option := metadata.BatchUpdateQuotedInstOption{
+				ObjID:      modelQuoteObj.ObjectID,
+				PropertyID: quoteProp.PropertyID,
+				IDs:        quoteInstIDArr,
+				Data: mapstr.MapStr{
+					"cc1":        30,
+					"cc2":        "ccc",
+					"bk_inst_id": instanceID,
+				},
+			}
+			err := modelQuoteClient.BatchUpdateQuotedInstance(ctx, header, &option)
+			Expect(err).ShouldNot(HaveOccurred())
+		}()
+
+		By("update model quote instance but model property no exist")
+		func() {
+			option := metadata.BatchUpdateQuotedInstOption{
+				ObjID:      modelQuoteObj.ObjectID,
+				PropertyID: "prop_no_exist",
+				IDs:        quoteInstIDArr,
+				Data: mapstr.MapStr{
+					"cc1":        30,
+					"cc2":        "ccc",
+					"bk_inst_id": instanceID,
+				},
+			}
+			err := modelQuoteClient.BatchUpdateQuotedInstance(ctx, header, &option)
+			Expect(err).To(HaveOccurred())
+		}()
+
+		By("list model quote instance")
+		func() {
+			option := metadata.ListQuotedInstOption{
+				ObjID:      modelQuoteObj.ObjectID,
+				PropertyID: quoteProp.PropertyID,
+				CommonQueryOption: metadata.CommonQueryOption{
+					Page: metadata.BasePage{
+						Limit: 100,
+					},
+				},
+			}
+			rsp, err := modelQuoteClient.ListQuotedInstance(ctx, header, &option)
+			testutil.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Info).To(HaveLen(2))
+			for _, inst := range rsp.Info {
+				instID, _ := inst.Get(common.BKInstIDField)
+				instIDInt64, err := util.GetInt64ByInterface(instID)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(instIDInt64).To(Equal(instanceID))
+				cc1Field, _ := inst.Get("cc1")
+				cc1FieldInt, err := util.GetIntByInterface(cc1Field)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cc1FieldInt).To(Equal(30))
+				cc2Field, _ := inst.Get("cc2")
+				Expect(cc2Field.(string)).To(Equal("ccc"))
+			}
+		}()
+
+		By("delete model quote instance")
+		func() {
+			option := metadata.BatchDeleteQuotedInstOption{
+				ObjID:      modelQuoteObj.ObjectID,
+				PropertyID: quoteProp.PropertyID,
+				IDs:        quoteInstIDArr,
+			}
+			err := modelQuoteClient.BatchDeleteQuotedInstance(ctx, header, &option)
+			Expect(err).ShouldNot(HaveOccurred())
+		}()
+
+		By("list model quote instance")
+		func() {
+			option := metadata.ListQuotedInstOption{
+				ObjID:      modelQuoteObj.ObjectID,
+				PropertyID: quoteProp.PropertyID,
+				CommonQueryOption: metadata.CommonQueryOption{
+					Page: metadata.BasePage{
+						Limit: 100,
+					},
+				},
+			}
+			rsp, err := modelQuoteClient.ListQuotedInstance(ctx, header, &option)
+			testutil.RegisterResponseWithRid(rsp, header)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rsp.Info).To(HaveLen(0))
+		}()
+	})
+})

--- a/src/test/topo_server/topo_server_suite_test.go
+++ b/src/test/topo_server/topo_server_suite_test.go
@@ -23,6 +23,8 @@ var serviceClient = clientSet.ProcServer().Service()
 var hostServerClient = test.GetClientSet().HostServer()
 
 var kubeClient = topoServerClient.Kube()
+var fieldTemplateClient = topoServerClient.FieldTemplate()
+var modelQuoteClient = apiServerClient.ModelQuote()
 
 func TestTopoServer(t *testing.T) {
 	RegisterFailHandler(util.Fail)


### PR DESCRIPTION
添加模型引用类型、字段组合模板功能测试用例:

1. 字段组合模版 https://github.com/TencentBlueKing/bk-cmdb/blob/v3.11.x/src/scene_server/topo_server/service/field_template/service.go

2. 表格类型 
实例相关：
https://github.com/TencentBlueKing/bk-cmdb/blob/v3.11.x/src/scene_server/topo_server/service/service_model_quote_initfunc.go

模型相关：
模型的表格字段crud以及其他场景的测试用例