### PR TITLE
fix: 表单项内容超出后支持悬浮样式

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -22,7 +22,7 @@
     "@icon-cool/bk-icon-cmdb-colorful": "0.0.1",
     "await-to-js": "^3.0.0",
     "axios": "0.18.0",
-    "bk-magic-vue": "2.5.9-beta.13",
+    "bk-magic-vue": "2.5.9-beta.15",
     "core-js": "^3.10.1",
     "cytoscape": "3.10.0",
     "cytoscape-dagre": "2.2.2",

--- a/src/ui/src/components/filters/store.js
+++ b/src/ui/src/components/filters/store.js
@@ -355,7 +355,12 @@ const FilterStore = new Vue({
       this.throttleSearch()
     },
     setConditonField(propertyId, value, modelId = 'host') {
-      const { id } = this.getProperty(propertyId, modelId)
+      const property = this.getProperty(propertyId, modelId)
+      const { id } = property
+      if (typeof value === 'undefined') {
+        value = Utils.getDefaultData(property).value
+      }
+
       this.setCondition({
         condition: {
           ...this.condition,

--- a/src/ui/src/components/filters/store.js
+++ b/src/ui/src/components/filters/store.js
@@ -354,17 +354,15 @@ const FilterStore = new Vue({
       this.setIP(data.IP || this.IP)
       this.throttleSearch()
     },
-    setConditonField(propertyId, value, modelId = 'host') {
+    setConditonField(propertyId, defaultData, modelId = 'host') {
       const property = this.getProperty(propertyId, modelId)
       const { id } = property
-      if (typeof value === 'undefined') {
-        value = Utils.getDefaultData(property).value
-      }
+      const defaultValueOperator = Utils.getDefaultData(property)
 
       this.setCondition({
         condition: {
           ...this.condition,
-          [id]: { operator: '$in', value }
+          [id]: Object.assign(defaultValueOperator, defaultData)
         }
       })
     },

--- a/src/ui/src/components/model-manage/field-group/index.vue
+++ b/src/ui/src/components/model-manage/field-group/index.vue
@@ -98,7 +98,7 @@
                   text: $t('编辑分组'),
                   auth: authResources,
                   onUpdateAuth: handleReceiveAuth,
-                  disabled: !isEditable(group.info),
+                  disabled: !isEditable(group.info) || group.info['bk_isdefault'],
                   handler: () => handleEditGroup(group)
                 },
                 {

--- a/src/ui/src/components/ui/form/form.vue
+++ b/src/ui/src/components/ui/form/form.vue
@@ -162,6 +162,10 @@
       submitting: {
         type: Boolean,
         default: false
+      },
+      slotAppendIsChange: {
+        type: Boolean,
+        default: false
       }
     },
     data() {
@@ -185,6 +189,7 @@
       hasChange() {
         return (!!Object.keys(this.changedValues).length)
           || (Object.keys(this.inst).length !== Object.keys(this.values).length)
+          || this.slotAppendIsChange
       },
       groupedProperties() {
         return this.$groupedProperties.map(properties => properties.filter((property) => {

--- a/src/ui/src/components/ui/form/longchar.vue
+++ b/src/ui/src/components/ui/form/longchar.vue
@@ -24,7 +24,8 @@
     @blur="handleBlur"
     @enter="handleEnter"
     @change="handleChange"
-    @on-change="handleChange">
+    @on-change="handleChange"
+    @focus="handleFocus">
   </bk-input>
 </template>
 
@@ -105,8 +106,17 @@
         this.$emit('enter', value)
       },
       handleBlur(value) {
-        this.$refs.autoSize.$el.querySelector('.bk-textarea-wrapper').style.height = `${this.minHeight}px`
+        const { autoSize } = this.$refs
+        const parent = autoSize.$el.querySelector('.bk-textarea-wrapper')
+        parent.style.height = `${this.minHeight}px`
+        parent.style.zIndex = ''
         this.$emit('blur', value)
+      },
+      handleFocus() {
+        const { autoSize } = this.$refs
+        const parent = autoSize.$el.querySelector('.bk-textarea-wrapper')
+        // eslint-disable-next-line no-underscore-dangle
+        parent.style.zIndex = window.__bk_zIndex_manager.nextZIndex()
       },
       focus() {
         const { autoSize } = this.$refs
@@ -141,6 +151,7 @@
             @include scrollbar-y;
             &:hover {
               height: auto !important;
+              z-index: 9999 !important;
             }
 
             .bk-form-textarea {

--- a/src/ui/src/components/ui/form/organization.vue
+++ b/src/ui/src/components/ui/form/organization.vue
@@ -26,7 +26,8 @@
       :popover-width="400"
       :scroll-height="400"
       :popover-options="{
-        sticky: true
+        sticky: true,
+        flipOnUpdate: true
       }"
       :searchable="true"
       :multiple="localMultiple"

--- a/src/ui/src/views/business-set/children/management-form.vue
+++ b/src/ui/src/views/business-set/children/management-form.vue
@@ -26,6 +26,7 @@
         :type="isEdit ? 'update' : 'create'"
         :save-auth="saveAuth"
         :submitting="submitting"
+        :slot-append-is-change="scopeChanged"
         @on-submit="handleSave"
         @on-cancel="handleSliderBeforeClose">
         <template #append>
@@ -112,6 +113,7 @@
       const isEmptyRuleValue = value => value === null || value === undefined || !value.toString().length
 
       const submitting = ref(false)
+      const scopeChanged = ref(false)
       const isEdit = computed(() => Boolean(formData.value.bk_biz_set_id))
       const title = computed(() => (isEdit.value ? t('编辑') : `${t('创建')} ${model.value.bk_obj_name}`))
 
@@ -157,7 +159,6 @@
       let saveData = defaultSaveData()
 
       let scopeCopy = null
-      let scopeChanged = false
 
       const handleSave = async (values, changedValues, originalValues, type) => {
         try {
@@ -171,7 +172,7 @@
               bk_biz_set_ids: [formData.value.bk_biz_set_id],
               data: {
                 ...saveData,
-                bk_scope: scopeChanged ? saveData.bk_scope : undefined,
+                bk_scope: scopeChanged.value ? saveData.bk_scope : undefined,
                 bk_biz_set_attr: { ...changedValues }
               }
             })
@@ -236,8 +237,7 @@
         if (!scopeCopy) {
           scopeCopy = cloneDeep(saveData.bk_scope)
         }
-
-        scopeChanged = !isEqual(scopeCopy, saveData.bk_scope)
+        scopeChanged.value = !isEqual(scopeCopy, saveData.bk_scope)
       }
 
       const resetData = () => {
@@ -245,7 +245,7 @@
         saveData = defaultSaveData()
 
         scopeCopy = null
-        scopeChanged = false
+        scopeChanged.value = false
       }
 
       const handleSliderBeforeClose = () => {
@@ -288,7 +288,8 @@
         previewProps,
         handlePreview,
         formRef,
-        businessSetFormRef
+        businessSetFormRef,
+        scopeChanged
       }
     }
   })

--- a/src/ui/src/views/business-topology/children/create-set.vue
+++ b/src/ui/src/views/business-topology/children/create-set.vue
@@ -54,7 +54,8 @@
           v-model="setName"
           :rows="rows"
           :placeholder="$t('集群多个创建提示')"
-          @keydown="handleKeydown">
+          @keydown="handleKeydown"
+          @paste="handlePaste">
         </bk-input>
         <span class="form-error" v-if="errors.has('setName')">{{errors.first('setName')}}</span>
       </div>
@@ -118,17 +119,20 @@
     },
     methods: {
       setRows() {
-        const rows = this.setName.split('\n').length
-        this.rows = Math.min(3, Math.max(rows, 1))
+        setTimeout(() => {
+          const rows = this.setName.split('\n').length
+          this.rows = Math.min(3, Math.max(rows, 1))
+        })
       },
       handleKeydown(value, keyEvent) {
         if (['Enter', 'NumpadEnter'].includes(keyEvent.code)) {
           this.rows = Math.min(this.rows + 1, 3)
         } else if (keyEvent.code === 'Backspace') {
-          this.$nextTick(() => {
-            this.setRows()
-          })
+          this.setRows()
         }
+      },
+      handlePaste() {
+        this.setRows()
       },
       async getSetTemplates() {
         if (has(this.setTemplateMap, this.business)) {

--- a/src/ui/src/views/index/children/host-search.vue
+++ b/src/ui/src/views/index/children/host-search.vue
@@ -181,7 +181,7 @@
         const propertyId = 'bk_asset_id'
 
         FilterStore.setIPField('text', IPText)
-        FilterStore.setConditonField(propertyId, '')
+        FilterStore.setConditonField(propertyId, [])
         this.ipEditableBlock.clear()
 
         if (type === 'asset') {

--- a/src/ui/src/views/index/children/host-search.vue
+++ b/src/ui/src/views/index/children/host-search.vue
@@ -60,6 +60,7 @@
   import FilterStore, { setupFilterStore } from '@/components/filters/store'
   import FilterForm from '@/components/filters/filter-form.js'
   import { LT_REGEXP } from '@/dictionary/regexp'
+  import { QUERY_OPERATOR } from '@/utils/query-builder-operator'
 
   export default {
     components: {
@@ -187,7 +188,7 @@
         if (type === 'asset') {
           FilterStore.setSelectedField(propertyId)
           FilterStore.setSelectedFieldIndex(propertyId)
-          FilterStore.setConditonField(propertyId, assetList)
+          FilterStore.setConditonField(propertyId, { operator: QUERY_OPERATOR.IN, value: assetList })
         }
         if (type !== 'fuzzy') {
           FilterStore.setIPField('exact', true)

--- a/src/ui/src/views/index/children/host-search.vue
+++ b/src/ui/src/views/index/children/host-search.vue
@@ -181,7 +181,7 @@
         const propertyId = 'bk_asset_id'
 
         FilterStore.setIPField('text', IPText)
-        FilterStore.setConditonField(propertyId, [])
+        FilterStore.setConditonField(propertyId)
         this.ipEditableBlock.clear()
 
         if (type === 'asset') {


### PR DESCRIPTION
### 修复的问题：
- textarea悬浮设置zIndex
- 组织下拉框增加flipOnUpdate属性
- cmdb-form组件增加对slot的内容进行校验是否修改过
- 修复首页-高级筛选下固资编号默认为''问题
- 新建集群, 粘贴名称时textarea设置rows
- 模型下内置分组不能编辑
