### PR TITLE
修复权限中心查询实例时输入正则表达式中的部分特殊字符时报错问题

### DIFF
--- a/src/apimachinery/apiserver/apiserver.go
+++ b/src/apimachinery/apiserver/apiserver.go
@@ -32,45 +32,66 @@ import (
 type ApiServerClientInterface interface {
 	Client() rest.ClientInterface
 
-	AddDefaultApp(ctx context.Context, h http.Header, ownerID string, params mapstr.MapStr) (resp *metadata.Response, err error)
+	AddDefaultApp(ctx context.Context, h http.Header, ownerID string, params mapstr.MapStr) (
+		resp *metadata.Response, err error)
 	SearchDefaultApp(ctx context.Context, h http.Header, ownerID string) (resp *metadata.QueryInstResult, err error)
-	GetObjectData(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.ObjectAttrBatchResult, err error)
-	GetInstDetail(ctx context.Context, h http.Header, objID string, params mapstr.MapStr) (resp *metadata.QueryInstResult, err error)
+	GetObjectData(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.ObjectAttrBatchResult,
+		err error)
+	GetInstDetail(ctx context.Context, h http.Header, objID string, params mapstr.MapStr) (
+		resp *metadata.QueryInstResult, err error)
 	GetInstUniqueFields(ctx context.Context, h http.Header, objID string, uniqueID int64, params mapstr.MapStr) (
 		resp metadata.QueryUniqueFieldsResult, err error)
 	CreateObjectAtt(ctx context.Context, h http.Header, obj *metadata.ObjAttDes) (resp *metadata.Response, err error)
-	UpdateObjectAtt(ctx context.Context, objID string, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
+	UpdateObjectAtt(ctx context.Context, objID string, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
 	DeleteObjectAtt(ctx context.Context, objID string, h http.Header) (resp *metadata.Response, err error)
-	GetObjectAttr(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.ObjectAttrResult, err error)
+	GetObjectAttr(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.ObjectAttrResult,
+		err error)
 	GetHostData(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.QueryInstResult, err error)
-	ListHostWithoutApp(ctx context.Context, h http.Header, option metadata.ListHostsWithNoBizParameter) (resp *metadata.ListHostWithoutAppResponse, err error)
-	GetObjectGroup(ctx context.Context, h http.Header, ownerID, objID string, params mapstr.MapStr) (resp *metadata.ObjectAttrGroupResult, err error)
+	ListHostWithoutApp(ctx context.Context, h http.Header, option metadata.ListHostsWithNoBizParameter) (
+		resp *metadata.ListHostWithoutAppResponse, err error)
+	GetObjectGroup(ctx context.Context, h http.Header, ownerID, objID string, params mapstr.MapStr) (
+		resp *metadata.ObjectAttrGroupResult, err error)
 	AddHost(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.ResponseDataMapStr, err error)
-	AddHostByExcel(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.ResponseDataMapStr, err error)
-	UpdateHost(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.ResponseDataMapStr, err error)
-	GetHostModuleRelation(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.HostModuleResp, err error)
-	AddInst(ctx context.Context, h http.Header, ownerID, objID string, params mapstr.MapStr) (resp *metadata.ResponseDataMapStr, err error)
+	AddHostByExcel(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.ResponseDataMapStr,
+		err error)
+	UpdateHost(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.ResponseDataMapStr,
+		err error)
+	GetHostModuleRelation(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.HostModuleResp,
+		err error)
+	AddInst(ctx context.Context, h http.Header, ownerID, objID string, params mapstr.MapStr) (
+		resp *metadata.ResponseDataMapStr, err error)
 	AddInstByImport(ctx context.Context, h http.Header, ownerID, objID string, params mapstr.MapStr) (
 		*metadata.ResponseDataMapStr, error)
 	AddObjectBatch(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.Response, err error)
-	SearchAssociationInst(ctx context.Context, h http.Header, request *metadata.SearchAssociationInstRequest) (resp *metadata.SearchAssociationInstResult, err error)
-	ImportAssociation(ctx context.Context, h http.Header, objID string, input *metadata.RequestImportAssociation) (resp *metadata.ResponeImportAssociation, err error)
+	SearchAssociationInst(ctx context.Context, h http.Header, request *metadata.SearchAssociationInstRequest) (
+		resp *metadata.SearchAssociationInstResult, err error)
+	ImportAssociation(ctx context.Context, h http.Header, objID string, input *metadata.RequestImportAssociation) (
+		resp *metadata.ResponeImportAssociation, err error)
 
-	GetUserAuthorizedBusinessList(ctx context.Context, h http.Header, user string) (resp *metadata.InstDataInfo, err error)
+	GetUserAuthorizedBusinessList(ctx context.Context, h http.Header, user string) (resp *metadata.InstDataInfo,
+		err error)
 
-	SearchNetCollectDevice(ctx context.Context, h http.Header, cond condition.Condition) (resp *metadata.ResponseInstData, err error)
-	SearchNetDeviceProperty(ctx context.Context, h http.Header, cond condition.Condition) (resp *metadata.ResponseInstData, err error)
-	SearchNetCollectDeviceBatch(ctx context.Context, h http.Header, cond mapstr.MapStr) (resp *metadata.ResponseInstData, err error)
-	SearchNetDevicePropertyBatch(ctx context.Context, h http.Header, cond mapstr.MapStr) (resp *metadata.ResponseInstData, err error)
+	SearchNetCollectDevice(ctx context.Context, h http.Header, cond condition.Condition) (
+		resp *metadata.ResponseInstData, err error)
+	SearchNetDeviceProperty(ctx context.Context, h http.Header, cond condition.Condition) (
+		resp *metadata.ResponseInstData, err error)
+	SearchNetCollectDeviceBatch(ctx context.Context, h http.Header, cond mapstr.MapStr) (
+		resp *metadata.ResponseInstData, err error)
+	SearchNetDevicePropertyBatch(ctx context.Context, h http.Header, cond mapstr.MapStr) (
+		resp *metadata.ResponseInstData, err error)
 
-	CreateBiz(ctx context.Context, ownerID string, h http.Header, dat map[string]interface{}) (resp *metadata.CreateInstResult, err error)
-	UpdateBiz(ctx context.Context, ownerID string, bizID string, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
+	CreateBiz(ctx context.Context, ownerID string, h http.Header, dat map[string]interface{}) (
+		resp *metadata.CreateInstResult, err error)
+	UpdateBiz(ctx context.Context, ownerID string, bizID string, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
 	UpdateBizDataStatus(ctx context.Context, ownerID string, flag common.DataStatusFlag, bizID int64,
 		h http.Header) errors.CCErrorCoder
 	UpdateBizPropertyBatch(ctx context.Context, h http.Header, param metadata.UpdateBizPropertyBatchParameter) (
 		resp *metadata.Response, err error)
 	DeleteBiz(ctx context.Context, h http.Header, param metadata.DeleteBizParam) (resp *metadata.Response, err error)
-	SearchBiz(ctx context.Context, ownerID string, h http.Header, s *params.SearchParams) (resp *metadata.SearchInstResult, err error)
+	SearchBiz(ctx context.Context, ownerID string, h http.Header, s *params.SearchParams) (
+		resp *metadata.SearchInstResult, err error)
 
 	ReadModuleAssociation(ctx context.Context, h http.Header, input *metadata.QueryCondition) (resp *metadata.
 		SearchAsstModelResp, err error)
@@ -78,7 +99,8 @@ type ApiServerClientInterface interface {
 		err error)
 	ReadInstance(ctx context.Context, h http.Header, objID string, input *metadata.QueryCondition) (resp *metadata.
 		QueryConditionResult, err error)
-	SearchObjectUnique(ctx context.Context, objID string, h http.Header) (resp *metadata.SearchUniqueResult, err error)
+	SearchObjectUnique(ctx context.Context, objID string, h http.Header) (resp *metadata.SearchUniqueResult,
+		err error)
 
 	FindAssociationByObjectAssociationID(ctx context.Context, h http.Header, objID string,
 		input metadata.FindAssociationByObjectAssociationIDRequest) (

--- a/src/apimachinery/procserver/process/api.go
+++ b/src/apimachinery/procserver/process/api.go
@@ -23,24 +23,35 @@ import (
 
 // ProcessClientInterface TODO
 type ProcessClientInterface interface {
-	CreateProcessInstance(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
+	CreateProcessInstance(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
 	DeleteProcessInstance(ctx context.Context, h http.Header,
 		data *metadata.DeleteProcessInstanceInServiceInstanceInput) error
 	SearchProcessInstance(ctx context.Context, h http.Header, data *metadata.ListProcessInstancesOption) (
 		[]metadata.ProcessInstance, error)
-	UpdateProcessInstance(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
+	UpdateProcessInstance(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
 
-	CreateProcessTemplate(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
-	DeleteProcessTemplate(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
-	SearchProcessTemplate(ctx context.Context, h http.Header, i *metadata.ListProcessTemplateWithServiceTemplateInput) (
+	CreateProcessTemplate(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
+	DeleteProcessTemplate(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
+	SearchProcessTemplate(ctx context.Context, h http.Header,
+		i *metadata.ListProcessTemplateWithServiceTemplateInput) (
 		*metadata.MultipleProcessTemplate, errors.CCErrorCoder)
-	UpdateProcessTemplate(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
+	UpdateProcessTemplate(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
 
-	ListProcessRelatedInfo(ctx context.Context, h http.Header, bizID int64, data metadata.ListProcessRelatedInfoOption) (resp *metadata.ListProcessRelatedInfoResponse, err error)
-	ListProcessInstancesNameIDsInModule(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
-	ListProcessInstancesDetailsByIDs(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
-	ListProcessInstancesDetails(ctx context.Context, h http.Header, bizID int64, data metadata.ListProcessInstancesDetailsOption) (resp *metadata.MapArrayResponse, err error)
-	UpdateProcessInstancesByIDs(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
+	ListProcessRelatedInfo(ctx context.Context, h http.Header, bizID int64,
+		data metadata.ListProcessRelatedInfoOption) (resp *metadata.ListProcessRelatedInfoResponse, err error)
+	ListProcessInstancesNameIDsInModule(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
+	ListProcessInstancesDetailsByIDs(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
+	ListProcessInstancesDetails(ctx context.Context, h http.Header, bizID int64,
+		data metadata.ListProcessInstancesDetailsOption) (resp *metadata.MapArrayResponse, err error)
+	UpdateProcessInstancesByIDs(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
 }
 
 // NewProcessClientInterface TODO

--- a/src/apimachinery/procserver/service/api.go
+++ b/src/apimachinery/procserver/service/api.go
@@ -11,30 +11,44 @@ import (
 
 // ServiceClientInterface TODO
 type ServiceClientInterface interface {
-	CreateServiceCategory(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
-	DeleteServiceCategory(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
+	CreateServiceCategory(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
+	DeleteServiceCategory(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
 	SearchServiceCategory(ctx context.Context, h http.Header, opt *metadata.ListServiceCategoryOption) (
 		*metadata.MultipleServiceCategory, errors.CCErrorCoder)
-	UpdateServiceCategory(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
+	UpdateServiceCategory(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
 
 	CreateServiceInstance(ctx context.Context, h http.Header, data *metadata.CreateServiceInstanceInput) ([]int64,
 		errors.CCErrorCoder)
-	UpdateServiceInstances(ctx context.Context, h http.Header, bizID int64, data map[string]interface{}) (resp *metadata.Response, err error)
-	DeleteServiceInstance(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
+	UpdateServiceInstances(ctx context.Context, h http.Header, bizID int64, data map[string]interface{}) (
+		resp *metadata.Response, err error)
+	DeleteServiceInstance(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
 	SearchServiceInstance(ctx context.Context, h http.Header, data *metadata.GetServiceInstanceInModuleInput) (
 		*metadata.MultipleServiceInstance, error)
-	SearchServiceInstanceBySetTemplate(ctx context.Context, appID string, h http.Header, data map[string]interface{}) (resp *metadata.ResponseInstData, err error)
-	ServiceInstanceAddLabels(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
-	ServiceInstanceRemoveLabels(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
-	ServiceInstanceFindLabels(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
+	SearchServiceInstanceBySetTemplate(ctx context.Context, appID string, h http.Header,
+		data map[string]interface{}) (resp *metadata.ResponseInstData, err error)
+	ServiceInstanceAddLabels(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
+	ServiceInstanceRemoveLabels(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
+	ServiceInstanceFindLabels(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.Response, err error)
 
-	CreateServiceTemplate(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.ResponseDataMapStr, err error)
+	CreateServiceTemplate(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.ResponseDataMapStr, err error)
 	DeleteServiceTemplate(ctx context.Context, h http.Header,
 		input *metadata.DeleteServiceTemplatesInput) errors.CCErrorCoder
-	SearchServiceTemplate(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.ResponseDataMapStr, err error)
-	FindServiceTemplateCountInfo(ctx context.Context, h http.Header, bizID int64, data map[string]interface{}) (resp *metadata.ArrayResponse, err error)
-	UpdateServiceTemplate(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.ResponseDataMapStr, err error)
-	RemoveTemplateBindingOnModule(ctx context.Context, h http.Header, data map[string]interface{}) (resp *metadata.ResponseDataMapStr, err error)
+	SearchServiceTemplate(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.ResponseDataMapStr, err error)
+	FindServiceTemplateCountInfo(ctx context.Context, h http.Header, bizID int64, data map[string]interface{}) (
+		resp *metadata.ArrayResponse, err error)
+	UpdateServiceTemplate(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.ResponseDataMapStr, err error)
+	RemoveTemplateBindingOnModule(ctx context.Context, h http.Header, data map[string]interface{}) (
+		resp *metadata.ResponseDataMapStr, err error)
 
 	CreateServiceTemplateAllInfo(ctx context.Context, h http.Header, opt *metadata.CreateSvcTempAllInfoOption) (int64,
 		errors.CCErrorCoder)

--- a/src/apimachinery/toposerver/inst/api.go
+++ b/src/apimachinery/toposerver/inst/api.go
@@ -49,7 +49,8 @@ type InstanceInterface interface {
 	SelectInstsByAssociation(ctx context.Context, objID string, h http.Header, p *metadata.AssociationParams) (resp *metadata.SearchInstResult, err error)
 	SelectInst(ctx context.Context, objID string, instID int64, h http.Header, p *metadata.SearchParams) (resp *metadata.SearchInstResult, err error)
 	SelectTopo(ctx context.Context, objID string, instID int64, h http.Header, p *metadata.SearchParams) (resp *metadata.SearchTopoResult, err error)
-	SelectAssociationTopo(ctx context.Context, objID string, instID int64, h http.Header, p *metadata.SearchParams) (resp *metadata.SearchAssociationTopoResult, err error)
+	SelectAssociationTopo(ctx context.Context, objID string, instID int64, h http.Header, p *metadata.SearchParams) (
+		resp *metadata.SearchAssociationTopoResult, err error)
 	CreateModule(ctx context.Context, appID, setID int64, h http.Header, dat map[string]interface{}) (mapstr.MapStr,
 		errors.CCErrorCoder)
 	DeleteModule(ctx context.Context, appID, setID, moduleID int64, h http.Header) errors.CCErrorCoder

--- a/src/apimachinery/toposerver/settemplate/apis.go
+++ b/src/apimachinery/toposerver/settemplate/apis.go
@@ -23,21 +23,30 @@ import (
 
 // SetTemplateInterface TODO
 type SetTemplateInterface interface {
-	CreateSetTemplate(ctx context.Context, h http.Header, bizID int64, option metadata.CreateSetTemplateOption) (*metadata.SetTemplateResult, errors.CCErrorCoder)
+	CreateSetTemplate(ctx context.Context, h http.Header, bizID int64, option metadata.CreateSetTemplateOption) (
+		*metadata.SetTemplateResult, errors.CCErrorCoder)
 	CreateSetTemplateAllInfo(ctx context.Context, h http.Header, option *metadata.CreateSetTempAllInfoOption) (
 		int64, errors.CCErrorCoder)
-	UpdateSetTemplate(ctx context.Context, header http.Header, bizID int64, setTemplateID int64, option metadata.UpdateSetTemplateOption) (*metadata.SetTemplateResult, errors.CCErrorCoder)
+	UpdateSetTemplate(ctx context.Context, header http.Header, bizID int64, setTemplateID int64,
+		option metadata.UpdateSetTemplateOption) (*metadata.SetTemplateResult, errors.CCErrorCoder)
 	UpdateSetTemplateAllInfo(ctx context.Context, header http.Header,
 		option *metadata.UpdateSetTempAllInfoOption) errors.CCErrorCoder
-	DeleteSetTemplate(ctx context.Context, header http.Header, bizID int64, option metadata.DeleteSetTemplateOption) errors.CCErrorCoder
-	GetSetTemplate(ctx context.Context, header http.Header, bizID int64, setTemplateID int64) (*metadata.SetTemplateResult, errors.CCErrorCoder)
+	DeleteSetTemplate(ctx context.Context, header http.Header, bizID int64,
+		option metadata.DeleteSetTemplateOption) errors.CCErrorCoder
+	GetSetTemplate(ctx context.Context, header http.Header, bizID int64, setTemplateID int64) (
+		*metadata.SetTemplateResult, errors.CCErrorCoder)
 	GetSetTemplateAllInfo(ctx context.Context, header http.Header, option *metadata.GetSetTempAllInfoOption) (
 		*metadata.SetTempAllInfo, errors.CCErrorCoder)
-	ListSetTemplate(ctx context.Context, header http.Header, bizID int64, option metadata.ListSetTemplateOption) (*metadata.MultipleSetTemplateResult, errors.CCErrorCoder)
-	ListSetTemplateWeb(ctx context.Context, header http.Header, bizID int64, option metadata.ListSetTemplateOption) (*metadata.MultipleSetTemplateResult, errors.CCErrorCoder)
-	ListSetTplRelatedSvcTpl(ctx context.Context, header http.Header, bizID int64, setTemplateID int64) ([]metadata.ServiceTemplate, errors.CCErrorCoder)
-	ListSetTplRelatedSetsWeb(ctx context.Context, header http.Header, bizID int64, setTemplateID int64, option metadata.ListSetByTemplateOption) (*metadata.InstDataInfo, errors.CCErrorCoder)
-	DiffSetTplWithInst(ctx context.Context, header http.Header, bizID int64, setTemplateID int64, option metadata.DiffSetTplWithInstOption) (*metadata.SetTplDiffResult, errors.CCErrorCoder)
+	ListSetTemplate(ctx context.Context, header http.Header, bizID int64, option metadata.ListSetTemplateOption) (
+		*metadata.MultipleSetTemplateResult, errors.CCErrorCoder)
+	ListSetTemplateWeb(ctx context.Context, header http.Header, bizID int64, option metadata.ListSetTemplateOption) (
+		*metadata.MultipleSetTemplateResult, errors.CCErrorCoder)
+	ListSetTplRelatedSvcTpl(ctx context.Context, header http.Header, bizID int64, setTemplateID int64) (
+		[]metadata.ServiceTemplate, errors.CCErrorCoder)
+	ListSetTplRelatedSetsWeb(ctx context.Context, header http.Header, bizID int64, setTemplateID int64,
+		option metadata.ListSetByTemplateOption) (*metadata.InstDataInfo, errors.CCErrorCoder)
+	DiffSetTplWithInst(ctx context.Context, header http.Header, bizID int64, setTemplateID int64,
+		option metadata.DiffSetTplWithInstOption) (*metadata.SetTplDiffResult, errors.CCErrorCoder)
 	SyncSetTplToInst(ctx context.Context, header http.Header, bizID int64, setTemplateID int64,
 		option *metadata.SyncSetTplToInstOption) errors.CCErrorCoder
 	UpdateSetTemplateAttr(ctx context.Context, header http.Header,

--- a/src/scene_server/auth_server/service/pull_resource.go
+++ b/src/scene_server/auth_server/service/pull_resource.go
@@ -14,6 +14,7 @@ package service
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"configcenter/src/common"
@@ -44,6 +45,13 @@ func (s *AuthService) PullResource(ctx *rest.Contexts) {
 	if err != nil {
 		ctx.RespBkError(types.NotFoundErrorCode, err.Error())
 		return
+	}
+
+	if queryFilter, ok := query.Filter.(types.ListInstanceFilter); ok {
+		if queryFilter.Keyword != "" {
+			queryFilter.Keyword = regexp.QuoteMeta(queryFilter.Keyword)
+			query.Filter = queryFilter
+		}
 	}
 
 	// get response data for each iam query method, if callback method is not set, returns empty data

--- a/src/scene_server/host_server/service/hostapplyrule.go
+++ b/src/scene_server/host_server/service/hostapplyrule.go
@@ -98,9 +98,11 @@ func (s *Service) UpdateHostApplyRule(ctx *rest.Contexts) {
 	var rule metadata.HostApplyRule
 	txnErr := s.Engine.CoreAPI.CoreService().Txn().AutoRunTxn(ctx.Kit.Ctx, ctx.Kit.Header, func() error {
 		var err error
-		rule, err = s.CoreAPI.CoreService().HostApplyRule().UpdateHostApplyRule(ctx.Kit.Ctx, ctx.Kit.Header, bizID, ruleID, option)
+		rule, err = s.CoreAPI.CoreService().HostApplyRule().UpdateHostApplyRule(ctx.Kit.Ctx, ctx.Kit.Header,
+			bizID, ruleID, option)
 		if err != nil {
-			blog.ErrorJSON("UpdateHostApplyRule failed, core service CreateHostApplyRule failed, bizID: %s, option: %s, err: %s, rid: %s", bizID, option, err.Error(), rid)
+			blog.ErrorJSON("UpdateHostApplyRule failed, core service CreateHostApplyRule failed, bizID: %s, "+
+				"option: %s, err: %s, rid: %s", bizID, option, err.Error(), rid)
 			return err
 		}
 		return nil

--- a/src/scene_server/proc_server/service/service.go
+++ b/src/scene_server/proc_server/service/service.go
@@ -89,10 +89,12 @@ func (ps *ProcServer) newProcessService(web *restful.WebService) {
 	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/delete/proc/service_category", Handler: ps.DeleteServiceCategory})
 
 	// service template
-	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/create/proc/service_template", Handler: ps.CreateServiceTemplate})
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/create/proc/service_template",
+		Handler: ps.CreateServiceTemplate})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/create/proc/service_template/all_info",
 		Handler: ps.CreateServiceTemplateAllInfo})
-	utility.AddHandler(rest.Action{Verb: http.MethodPut, Path: "/update/proc/service_template", Handler: ps.UpdateServiceTemplate})
+	utility.AddHandler(rest.Action{Verb: http.MethodPut, Path: "/update/proc/service_template",
+		Handler: ps.UpdateServiceTemplate})
 	utility.AddHandler(rest.Action{Verb: http.MethodPut, Path: "/update/proc/service_template/all_info",
 		Handler: ps.UpdateServiceTemplateAllInfo})
 	utility.AddHandler(rest.Action{Verb: http.MethodPut,
@@ -135,7 +137,8 @@ func (ps *ProcServer) newProcessService(web *restful.WebService) {
 	// process template
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/createmany/proc/proc_template", Handler: ps.CreateProcessTemplateBatch})
 	utility.AddHandler(rest.Action{Verb: http.MethodPut, Path: "/update/proc/proc_template", Handler: ps.UpdateProcessTemplate})
-	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/deletemany/proc/proc_template", Handler: ps.DeleteProcessTemplateBatch})
+	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/deletemany/proc/proc_template",
+		Handler: ps.DeleteProcessTemplateBatch})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/proc/proc_template/id/{processTemplateID}", Handler: ps.GetProcessTemplate})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/findmany/proc/proc_template", Handler: ps.ListProcessTemplate})
 

--- a/src/source_controller/coreservice/core/hostapplyrule/rule.go
+++ b/src/source_controller/coreservice/core/hostapplyrule/rule.go
@@ -344,7 +344,8 @@ func (p *hostApplyRule) ListHostApplyRule(kit *rest.Kit, bizID int64, option met
 	query := mongodb.Client().Table(common.BKTableNameHostApplyRule).Find(filter)
 	total, err := query.Count(kit.Ctx)
 	if err != nil {
-		blog.ErrorJSON("ListHostApplyRule failed, db count failed, filter: %s, err: %s, rid: %s", filter, err.Error(), kit.Rid)
+		blog.ErrorJSON("ListHostApplyRule failed, db count failed, filter: %s, err: %s, rid: %s", filter,
+			err.Error(), kit.Rid)
 		return result, kit.CCError.CCError(common.CCErrCommDBSelectFailed)
 	}
 	result.Count = int64(total)


### PR DESCRIPTION
### 修复的问题：
- 修复权限中心查询实例时输入正则表达式中的部分特殊字符时报错问题

说明：后续不再使用正则匹配，而是简单的字符串模糊匹配，所有输入均转义为普通字符串
