### PR TITLE
修复权限中心查询实例时输入正则表达式中的部分特殊字符时报错问题

### DIFF
--- a/src/scene_server/auth_server/service/pull_resource.go
+++ b/src/scene_server/auth_server/service/pull_resource.go
@@ -14,6 +14,7 @@ package service
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"configcenter/src/common"
@@ -115,6 +116,10 @@ func (s *AuthService) listInstance(kit *rest.Kit, method types.ResourcePullMetho
 	filter, err := s.lgc.ValidateListInstanceRequest(kit, query)
 	if err != nil {
 		return nil, err
+	}
+
+	if filter.Keyword != "" {
+		filter.Keyword = regexp.QuoteMeta(filter.Keyword)
 	}
 
 	res, err := method.ListInstance(kit, query.Type, filter, query.Page)


### PR DESCRIPTION
### 修复的问题：
- 修复权限中心查询实例时输入正则表达式中的部分特殊字符时报错问题
