### PR TITLE
fix: 动态分组预览滚动到底部线条不对齐

### DIFF
--- a/src/ui/src/views/business/index.vue
+++ b/src/ui/src/views/business/index.vue
@@ -569,10 +569,10 @@
       },
       getTableData() {
         this.getBusinessList({ cancelPrevious: true, globalPermission: false }).then((data) => {
-          if (data.count && !data.info.length) {
-            this.table.pagination.current -= 1
-            this.getTableData()
-          }
+          const { current, limit } = this.table.pagination
+          const { count } = data
+
+          this.table.pagination.current = Math.min(current, Math.ceil(count / limit))
           this.table.list = data.info
           this.table.pagination.count = data.count
 

--- a/src/ui/src/views/dynamic-group/index.vue
+++ b/src/ui/src/views/dynamic-group/index.vue
@@ -187,7 +187,8 @@
           id: '',
           modify_user: '',
           bk_obj_id: '',
-          _t: Date.now()
+          _t: Date.now(),
+          page: 1
         }
         // 处理 如果是bk_obj_id 将路由上的中文name 换成 id
         filter.forEach((item) => {

--- a/src/ui/src/views/dynamic-group/preview/preview-result.vue
+++ b/src/ui/src/views/dynamic-group/preview/preview-result.vue
@@ -666,11 +666,6 @@
     :deep(.bk-table-pagination-wrapper) {
       z-index: 9;
     }
-
-    :deep(.bk-table-body-wrapper ) {
-      @include scrollbar-y;
-      overflow-x: auto;
-    }
   }
 }
 

--- a/src/ui/src/views/field-template/index.vue
+++ b/src/ui/src/views/field-template/index.vue
@@ -406,7 +406,8 @@
       templateName: '',
       modelName: '',
       modifier: '',
-      _t: Date.now()
+      _t: Date.now(),
+      page: 1
     }
     filter.forEach((item) => {
       query[item.id] = item.values.map(val => val.name).join(',')


### PR DESCRIPTION
### 修复的问题：
- 动态分组预览滚动到底部线条不对齐
- 搜索存在的字段模板名称，前端提示搜索为空
- 资源-业务下当存在21个业务出现翻页后，归档下一页第21条业务后，页面显示没有业务权限
