### PR TITLE
修复execute_dynamic_group接口锁定条件为时间类型且可变条件没有的情况下panic的问题

### DIFF
--- a/src/scene_server/host_server/service/dynamic_grouping.go
+++ b/src/scene_server/host_server/service/dynamic_grouping.go
@@ -692,6 +692,10 @@ func parseCond(conditions []meta.DynamicGroupInfoCondition) []meta.SearchConditi
 			conditionMap[cond.ObjID].Condition = append(conditionMap[cond.ObjID].Condition, condItem)
 		}
 
+		if cond.TimeCondition == nil {
+			continue
+		}
+
 		if conditionMap[cond.ObjID].TimeCondition == nil {
 			conditionMap[cond.ObjID].TimeCondition = cond.TimeCondition
 			continue


### PR DESCRIPTION
### 修复的问题：
- 修复execute_dynamic_group接口锁定条件为时间类型且可变条件没有的情况下panic的问题
