### PR TITLE
修复一些watch相关问题

### DIFF
--- a/src/storage/stream/event/list_watch.go
+++ b/src/storage/stream/event/list_watch.go
@@ -59,6 +59,7 @@ func (e *Event) ListWatch(ctx context.Context, opts *types.ListWatchOptions) (*t
 				opts.Collection, err)
 			// reset the resume token, because we can not use the former resume token to watch success for now.
 			streamOptions.StartAfter = nil
+			opts.StartAfterToken = nil
 			// cause we have already got a fatal error, we can not try to watch from where we lost.
 			// so re-watch from 1 minutes ago to avoid lost events.
 			// Note: apparently, we may got duplicate events with this re-watch
@@ -67,6 +68,7 @@ func (e *Event) ListWatch(ctx context.Context, opts *types.ListWatchOptions) (*t
 				T: startAtTime,
 				I: 0,
 			}
+			opts.StartAtTime = &types.TimeStamp{Sec: startAtTime}
 
 			if opts.WatchFatalErrorCallback != nil {
 				err := opts.WatchFatalErrorCallback(types.TimeStamp{Sec: startAtTime})


### PR DESCRIPTION
### 修复的问题：
- 修复一些watch相关问题

1. 当watch使用的token或起始时间太老导致oplog中对应数据已被删除时，mongodb可能会报错`(CappedPositionLost) Error in $cursor stage :: caused by :: CollectionScan died due to position in capped collection being deleted. Last seen record id: RecordId(xxx)`，此时cacheservice会报错退出。这种情况下应该将这个报错当作watch的FatalError来处理，从当前时间节点开始监听
2. watch遇到FatalError时会重置streamOptions里的token和起始时间，但是cc的watch opts的token和起始时间没有一起重置，然后重试时只会拉取db里最新的token而不会拉取起始时间，导致根据cc的watch opts重新生成streamOptions时会从进程启动时设置的起始时间开始监听