### PR TITLE
修复search_host接口问题

### DIFF
--- a/src/common/paraparse/host.go
+++ b/src/common/paraparse/host.go
@@ -38,7 +38,12 @@ func ParseHostParams(input []metadata.ConditionItem) (map[string]interface{}, er
 	output := make(map[string]interface{})
 	for _, i := range input {
 		switch i.Operator {
-		case common.BKDBEQ, common.BKDBNE:
+		case common.BKDBEQ:
+			output[i.Field], err = common.ConvertIpv6ToFullWord(i.Field, i.Value)
+			if err != nil {
+				return nil, err
+			}
+		case common.BKDBNE:
 			value, err := common.ConvertIpv6ToFullWord(i.Field, i.Value)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
### 修复的问题：
- 修复search_host接口在设置了hostID条件和业务条件时拼接条件为特殊格式`{"field": "bk_host_id", "operator": "$eq", "value": {"$in": [1,2], "$eq": 1}}`时解析错误的问题
