### PR TITLE
下发hostid文件大小限制调整为100kb

### DIFF
--- a/src/scene_server/event_server/sync/hostidentifier/common.go
+++ b/src/scene_server/event_server/sync/hostidentifier/common.go
@@ -34,8 +34,8 @@ const (
 	// maxSecondForSleep is the maximum number of seconds of sleep
 	maxSecondForSleep = 60
 
-	// fileLimit 10 * 1024 字节 = 10KB
-	fileLimit = 10240
+	// fileLimit 100 * 1024 字节 = 100KB
+	fileLimit = 102400
 )
 
 func strMd5(str string) (retMd5 string) {


### PR DESCRIPTION
### 优化的功能:
- 下发hostid文件大小限制调整为100kb