### PR TITLE
fix: 高级筛选 和 通用模型实例的高级筛选 悬浮框被遮挡

### DIFF
--- a/src/ui/src/components/search/array.vue
+++ b/src/ui/src/components/search/array.vue
@@ -21,7 +21,8 @@
       :list="[]"
       @removeAll="() => $emit('clear')"
       @click.native="handleToggle(true)"
-      @blur="handleToggle(false, ...arguments)">
+      @blur="handleToggle(false, ...arguments)"
+      @inputchange="handleInputChange">
     </bk-tag-input>
   </div>
   <bk-input v-else
@@ -95,6 +96,9 @@
           .filter(value => value.length)
         const value = [...new Set([...this.localValue, ...values])]
         this.localValue = value
+      },
+      handleInputChange(value) {
+        this.$emit('inputchange', value)
       }
     }
   }

--- a/src/ui/src/components/search/longchar.vue
+++ b/src/ui/src/components/search/longchar.vue
@@ -22,7 +22,8 @@
       :has-delete-icon="true"
       @removeAll="() => $emit('clear')"
       @click.native="handleToggle(true)"
-      @blur="handleToggle(false, ...arguments)">
+      @blur="handleToggle(false, ...arguments)"
+      @inputchange="handleInputChange">
     </bk-tag-input>
   </div>
   <bk-input v-else
@@ -89,6 +90,9 @@
           .filter(value => value.length)
         const value = [...new Set([...this.localValue, ...values])]
         this.localValue = value
+      },
+      handleInputChange(value) {
+        this.$emit('inputchange', value)
       }
     }
   }

--- a/src/ui/src/components/search/map.vue
+++ b/src/ui/src/components/search/map.vue
@@ -20,7 +20,8 @@
       :list="list"
       @removeAll="() => $emit('clear')"
       @click.native="handleToggle(true)"
-      @blur="handleToggle(false, ...arguments)">
+      @blur="handleToggle(false, ...arguments)"
+      @inputchange="handleInputChange">
     </bk-tag-input>
   </div>
 </template>
@@ -70,6 +71,9 @@
       }
     },
     methods: {
+      handleInputChange(value) {
+        this.$emit('inputchange', value)
+      }
     }
   }
 </script>

--- a/src/ui/src/components/search/singlechar.vue
+++ b/src/ui/src/components/search/singlechar.vue
@@ -22,7 +22,8 @@
       :has-delete-icon="true"
       @removeAll="() => $emit('clear')"
       @click.native="handleToggle(true)"
-      @blur="handleToggle(false, ...arguments)">
+      @blur="handleToggle(false, ...arguments)"
+      @inputchange="handleInputChange">
     </bk-tag-input>
   </div>
   <bk-input v-else
@@ -99,6 +100,9 @@
           .filter(value => value.length)
         const value = [...new Set([...this.localValue, ...values])]
         this.localValue = value
+      },
+      handleInputChange(value) {
+        this.$emit('inputchange', value)
       }
     }
   }

--- a/src/ui/src/components/search/table.vue
+++ b/src/ui/src/components/search/table.vue
@@ -21,7 +21,8 @@
       :list="[]"
       @removeAll="() => $emit('clear')"
       @click.native="handleToggle(true)"
-      @blur="handleToggle(false, ...arguments)">
+      @blur="handleToggle(false, ...arguments)"
+      @inputchange="handleInputChange">
     </bk-tag-input>
   </div>
   <bk-input v-else
@@ -77,6 +78,9 @@
           .filter(value => value.length)
         const value = [...new Set([...this.localValue, ...values])]
         this.localValue = value
+      },
+      handleInputChange(value) {
+        this.$emit('inputchange', value)
       }
     }
   }

--- a/src/ui/src/views/dynamic-group/form/form-property-list.vue
+++ b/src/ui/src/views/dynamic-group/form/form-property-list.vue
@@ -50,7 +50,8 @@
                 theme: 'light',
                 trigger: 'click',
                 content: property.placeholder
-              }">
+              }"
+              @inputchange="hanleInputChange">
             </component>
           </div>
           <i class="item-remove bk-icon icon-close" v-if="!disabled" @click="handleRemove(property)"></i>
@@ -154,6 +155,9 @@
         this.calcPosition('click')
       },
       handleChange() {
+        this.calcPosition()
+      },
+      hanleInputChange() {
         this.calcPosition()
       },
       handleShow() {


### PR DESCRIPTION
### 修复的问题：
-  高级筛选 和 通用模型实例的高级筛选 悬浮框被遮挡
