### PR TITLE
fix: 主机自动应用后，去除“返回”按钮；

### DIFF
--- a/src/ui/src/components/layout/header.vue
+++ b/src/ui/src/components/layout/header.vue
@@ -238,6 +238,7 @@
       color: #fff;
       font-size: 16px;
       background: v-bind(appLogo) no-repeat 0 center;
+      background-size: 28px;
     }
   }
   .header-nav {

--- a/src/ui/src/service/business/search.js
+++ b/src/ui/src/service/business/search.js
@@ -54,7 +54,7 @@ const findByIds = async ({ ids, config }) => {
 const findAll = async () => {
   const data = await http.get('biz/simplify?sort=bk_biz_id', {
     requestId: findAllRequsetId,
-    fromCache: true
+    fromCache: false
   })
 
   return Object.freeze(data.info || [])

--- a/src/ui/src/views/business-set/index.vue
+++ b/src/ui/src/views/business-set/index.vue
@@ -76,7 +76,7 @@
           </cmdb-property-value>
         </template>
       </bk-table-column>
-      <bk-table-column :label="$t('操作')" fixed="right">
+      <bk-table-column :label="$t('操作')" fixed="right" min-width="154">
         <template slot-scope="{ row }">
           <cmdb-auth class="mr10" :auth="{ type: $OPERATION.R_BIZ_SET_RESOURCE, relation: [row.bk_biz_set_id] }">
             <template slot-scope="{ disabled }">

--- a/src/ui/src/views/cloud-account/index.vue
+++ b/src/ui/src/views/cloud-account/index.vue
@@ -71,7 +71,7 @@
       <bk-table-column :label="$t('修改时间')" prop="last_time" sortable="custom">
         <template slot-scope="{ row }">{{row.last_time | formatter('time')}}</template>
       </bk-table-column>
-      <bk-table-column :label="$t('操作')">
+      <bk-table-column :label="$t('操作')" fixed="right" min-width="125">
         <template slot-scope="{ row }">
           <link-button class="mr10" @click="handleView(row)">{{$t('查看')}}</link-button>
           <cmdb-auth :auth="{ type: $OPERATION.D_CLOUD_ACCOUNT, relation: [row.bk_account_id] }">

--- a/src/ui/src/views/global-config/children/business-general-config.vue
+++ b/src/ui/src/views/global-config/children/business-general-config.vue
@@ -29,7 +29,8 @@
         <bk-input
           class="max-biz-topo-level-input"
           type="number"
-          :min="0"
+          :min="3"
+          :max="10"
           :precision="0"
           v-model.number.trim="bizGeneralForm.maxBizTopoLevel">
           <template #append>

--- a/src/ui/src/views/host-apply/failed-list.vue
+++ b/src/ui/src/views/host-apply/failed-list.vue
@@ -290,8 +290,7 @@
         }
         this.$routerActions.redirect({
           name: MENU_BUSINESS_HOST_AND_SERVICE,
-          query,
-          history: true
+          query
         })
       },
       handleViewFailed() {

--- a/src/ui/src/views/host-apply/property-run.vue
+++ b/src/ui/src/views/host-apply/property-run.vue
@@ -302,8 +302,7 @@
         this.$nextTick(() => {
           this.$routerActions.redirect({
             name: MENU_BUSINESS_HOST_AND_SERVICE,
-            query,
-            history: true
+            query
           })
         })
       },

--- a/src/ui/src/views/resource/children/directory.vue
+++ b/src/ui/src/views/resource/children/directory.vue
@@ -223,14 +223,15 @@
       },
       async createdDir() {
         try {
+          const { name } = this.createInfo
           const data = await this.$store.dispatch('resourceDirectory/createDirectory', {
             params: {
-              bk_module_name: this.createInfo.name
+              bk_module_name: name
             }
           })
           const newDir = {
             bk_module_id: data.created.id,
-            bk_module_name: this.createInfo.name,
+            bk_module_name: name,
             host_count: 0
           }
           this.$store.commit('resourceHost/addDirectory', newDir)


### PR DESCRIPTION
### 修复的问题：
- 主机自动应用后，去除“返回”按钮；
- 产品logo没有自适应大小
- 创建主机目录时，输入目录名称点击enter键，鼠标马上点击空白页面失焦后，创建出来的目录没有显示名称
- 平台管理可建层级范围3-10
- 业务集/云账户操作列定宽
- 业务归档后再点击业务会显示空白

