### PR TITLE
去掉servicemonitor.yaml中的namespaceSelector字段

### DIFF
--- a/docs/support-file/helm/templates/servicemonitor.yaml
+++ b/docs/support-file/helm/templates/servicemonitor.yaml
@@ -11,8 +11,6 @@ spec:
       {{- if .Values.serviceMonitor.metricRelabelings }}
       metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
       {{- end }}
-  namespaceSelector:
-    any: true
   selector:
     matchLabels:
       app.kubernetes.io/name: bk-cmdb


### PR DESCRIPTION
### 优化的功能:
- 去掉servicemonitor.yaml中的namespaceSelector字段
