### PR TITLE
修复saas将请求proxy到apigw时遗漏URL参数的问题

### DIFF
--- a/src/thirdparty/apigw/cmdb/api.go
+++ b/src/thirdparty/apigw/cmdb/api.go
@@ -61,6 +61,7 @@ func (c *cmdb) Proxy(req *http.Request, rw http.ResponseWriter) {
 		WithContext(req.Context()).
 		Body(body).
 		SubResourcef(req.URL.Path).
+		WithParamsFromURL(req.URL).
 		WithHeaders(c.SetApiGWAuthHeader(req.Header)).
 		Do()
 


### PR DESCRIPTION
### 修复的问题：
- 修复saas将请求proxy到apigw时遗漏URL参数的问题
