### PR TITLE
修复操作审计—>其他Tab，操作对象=模型分组、模型，动作有误问题

### DIFF
--- a/src/apimachinery/toposerver/inst/api.go
+++ b/src/apimachinery/toposerver/inst/api.go
@@ -47,7 +47,8 @@ type InstanceInterface interface {
 	SelectInstsAndAsstDetail(ctx context.Context, objID string, h http.Header, s *metadata.SearchParams) (resp *metadata.SearchInstResult, err error)
 	InstSearch(ctx context.Context, objID string, h http.Header, s *metadata.SearchParams) (resp *metadata.SearchInstResult, err error)
 	SelectInstsByAssociation(ctx context.Context, objID string, h http.Header, p *metadata.AssociationParams) (resp *metadata.SearchInstResult, err error)
-	SelectInst(ctx context.Context, objID string, instID int64, h http.Header, p *metadata.SearchParams) (resp *metadata.SearchInstResult, err error)
+	SelectInst(ctx context.Context, objID string, instID int64, h http.Header, p *metadata.SearchParams) (
+		resp *metadata.SearchInstResult, err error)
 	SelectTopo(ctx context.Context, objID string, instID int64, h http.Header, p *metadata.SearchParams) (resp *metadata.SearchTopoResult, err error)
 	SelectAssociationTopo(ctx context.Context, objID string, instID int64, h http.Header, p *metadata.SearchParams) (
 		resp *metadata.SearchAssociationTopoResult, err error)

--- a/src/common/metadata/audit.go
+++ b/src/common/metadata/audit.go
@@ -922,8 +922,6 @@ var auditDict = []resourceTypeInfo{
 			actionInfoMap[AuditCreate],
 			actionInfoMap[AuditUpdate],
 			actionInfoMap[AuditDelete],
-			actionInfoMap[AuditPause],
-			actionInfoMap[AuditResume],
 		},
 	},
 	{
@@ -933,6 +931,8 @@ var auditDict = []resourceTypeInfo{
 			actionInfoMap[AuditCreate],
 			actionInfoMap[AuditUpdate],
 			actionInfoMap[AuditDelete],
+			actionInfoMap[AuditPause],
+			actionInfoMap[AuditResume],
 		},
 	},
 	{
@@ -1149,8 +1149,6 @@ var auditEnDict = []resourceTypeInfo{
 			actionInfoEnMap[AuditCreate],
 			actionInfoEnMap[AuditUpdate],
 			actionInfoEnMap[AuditDelete],
-			actionInfoEnMap[AuditPause],
-			actionInfoEnMap[AuditResume],
 		},
 	},
 	{
@@ -1160,6 +1158,8 @@ var auditEnDict = []resourceTypeInfo{
 			actionInfoEnMap[AuditCreate],
 			actionInfoEnMap[AuditUpdate],
 			actionInfoEnMap[AuditDelete],
+			actionInfoEnMap[AuditPause],
+			actionInfoEnMap[AuditResume],
 		},
 	},
 	{

--- a/src/scene_server/proc_server/service/service.go
+++ b/src/scene_server/proc_server/service/service.go
@@ -86,7 +86,8 @@ func (ps *ProcServer) newProcessService(web *restful.WebService) {
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/findmany/proc/service_category/with_statistics", Handler: ps.ListServiceCategoryWithStatistics})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/create/proc/service_category", Handler: ps.CreateServiceCategory})
 	utility.AddHandler(rest.Action{Verb: http.MethodPut, Path: "/update/proc/service_category", Handler: ps.UpdateServiceCategory})
-	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/delete/proc/service_category", Handler: ps.DeleteServiceCategory})
+	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/delete/proc/service_category",
+		Handler: ps.DeleteServiceCategory})
 
 	// service template
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/create/proc/service_template",


### PR DESCRIPTION
修复操作审计—>其他Tab，操作对象=模型分组、模型，动作有误问题
