### PR TITLE
3.11修复list_hosts_without_biz接口的排序功能失效问题

### DIFF
--- a/src/scene_server/host_server/service/findhost.go
+++ b/src/scene_server/host_server/service/findhost.go
@@ -637,7 +637,9 @@ func (s *Service) ListHostsWithNoBiz(ctx *rest.Contexts) {
 		return
 	}
 
-	parameter.Page.Sort = common.BKHostIDField
+	if parameter.Page.Sort == "" {
+		parameter.Page.Sort = common.BKHostIDField
+	}
 	option := &meta.ListHosts{
 		HostPropertyFilter: parameter.HostPropertyFilter,
 		Fields:             parameter.Fields,


### PR DESCRIPTION
### 修复的问题：
- 3.11修复list_hosts_without_biz接口的排序功能失效问题
