### PR TITLE
fix: 锁定plotly.js版本解决build错误

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -48,7 +48,7 @@
     "md5": "2.2.1",
     "mockjs": "^1.1.0",
     "moment": "^2.30.1",
-    "plotly.js": "^2.30.1",
+    "plotly.js": "2.34.0",
     "postcss-gap-properties": "3.0.3",
     "prismjs": "^1.29.0",
     "qs": "^6.9.4",


### PR DESCRIPTION
### 修复的问题：
- 锁定plotly.js版本解决build错误
