### PR TITLE
fix:修复当streamTo不存在时，apigw接口查询报错的问题

### DIFF
--- a/src/thirdparty/apigw/gse/api.go
+++ b/src/thirdparty/apigw/gse/api.go
@@ -182,6 +182,11 @@ func (p *gse) ConfigQueryStreamTo(ctx context.Context, h http.Header, data *meta
 		return nil, err
 	}
 
+	// special error code for streamTo not exists
+	if resp.Code == 14001 || resp.Code == 1014003 || resp.Code == 1014505 {
+		return make([]metadata.GseConfigAddStreamToParams, 0), nil
+	}
+
 	if resp.Code != 0 {
 		return nil, fmt.Errorf("gse config query streamto failed, code: %d, message: %s", resp.Code, resp.Message)
 	}


### PR DESCRIPTION
### 修复的问题：
- fix:修复当streamTo不存在时，apigw接口查询报错的问题
