### PR TITLE
去除动态分组$in操作符的string类型校验

### DIFF
--- a/src/common/metadata/dynamic_grouping.go
+++ b/src/common/metadata/dynamic_grouping.go
@@ -136,11 +136,6 @@ func (c *DynamicGroupCondition) Validate(attributeMap map[string]string) error {
 	case DynamicGroupOperatorEQ, DynamicGroupOperatorNE:
 		return validAttributeValueType(attrType, c.Value)
 	case DynamicGroupOperatorIN, DynamicGroupOperatorNIN:
-		if attrType != stringType {
-			return fmt.Errorf("operator %s only support string value, not support attribute type, %s", c.Operator,
-				attributeType)
-		}
-
 		valueArr, ok := c.Value.([]interface{})
 		if !ok {
 			return fmt.Errorf("operator %s only support array value, not support value, %+v", c.Operator, c.Value)


### PR DESCRIPTION
### 优化的功能:
- 去除动态分组$in操作符的string类型校验
