### PR TITLE
fix: 收藏条件增加基本类型值判断

### DIFF
--- a/src/ui/src/assets/scss/common.scss
+++ b/src/ui/src/assets/scss/common.scss
@@ -457,6 +457,11 @@ input.cmdb-form-input {
             right: 0;
         }
 }
+.no-expand {
+    .g-expand {
+        position: inherit !important;
+    }
+}
 
 .g-cell-link-content {
     color: $primaryColor;

--- a/src/ui/src/components/filters/utils.js
+++ b/src/ui/src/components/filters/utils.js
@@ -497,6 +497,8 @@ export function getInitialProperties(properties) {
 }
 
 export function isEmptyCondition(value) {
+  const isObject = typeof value === 'object'
+  if (!isObject) return value === ''
   return isEmpty(value)
 }
 

--- a/src/ui/src/components/model-manage/field-group/index.vue
+++ b/src/ui/src/components/model-manage/field-group/index.vue
@@ -93,6 +93,7 @@
               :collapse="groupCollapseState[group.info.bk_group_id]"
               :title="`${group.info.bk_group_name} ( ${group.properties.length} )`"
               @click.native="toggleGroup(group)"
+              @showOperation="handleShowOperation"
               :commands="[
                 {
                   text: $t('编辑分组'),
@@ -379,6 +380,13 @@
         </template>
       </i18n>
     </div>
+
+    <model-operation-list
+      :show="modelOperationList.show"
+      :commands="modelOperationList.commands"
+      :target="modelOperationList.target"
+      @hide="handleHide">
+    </model-operation-list>
   </div>
 </template>
 
@@ -396,6 +404,7 @@
   import { BUILTIN_MODELS } from '@/dictionary/model-constants'
   import { v4 as uuidv4 } from 'uuid'
   import CollapseGroupTitle from '@/views/model-manage/children/collapse-group-title.vue'
+  import ModelOperationList from '@/views/model-manage/children/model-operation-list.vue'
   import { PROPERTY_TYPE_NAMES } from '@/dictionary/property-constants'
   import FieldCard from '@/components/model-manage/field-card.vue'
   import useUnique from '@/views/field-template/children/use-unique.js'
@@ -414,7 +423,8 @@
       CmdbColumnsConfig,
       CollapseGroupTitle,
       FieldCard,
-      MiniTag
+      MiniTag,
+      ModelOperationList
     },
     props: {
       customObjId: String,
@@ -484,6 +494,11 @@
           instance: null,
           template: {},
           requestId: ''
+        },
+        modelOperationList: {
+          show: false,
+          commands: [],
+          target: null
         }
       }
     },
@@ -603,6 +618,16 @@
       ...mapActions('objectUnique', [
         'searchObjectUniqueConstraints',
       ]),
+      handleShowOperation(event, commands) {
+        this.modelOperationList.show = true
+        this.modelOperationList.commands = commands
+        this.modelOperationList.target = event?.target
+      },
+      handleHide() {
+        this.modelOperationList.show = false
+        this.modelOperationList.commands = []
+        this.modelOperationList.target = null
+      },
       toggleGroup(group) {
         this.groupCollapseState[`${group.info.bk_group_id}`] = !this.groupCollapseState[`${group.info.bk_group_id}`]
       },

--- a/src/ui/src/views/model-manage/children/model-details/index.vue
+++ b/src/ui/src/views/model-manage/children/model-details/index.vue
@@ -99,7 +99,7 @@
                   {{$t('所属分组')}}
                 </span>
                 <editable-field
-                  class="model-group-name-edit"
+                  class="model-group-name-edit no-expand"
                   :editing.sync="modelGroupIsEditing"
                   v-model="activeModel.bk_classification_id"
                   :label="modelClassificationName"
@@ -110,6 +110,7 @@
                   font-size="12px"
                   style="width: calc(100% - 60px)"
                   :options="classifications
+                    .filter(item => !item.bk_ishidden)
                     .map(item => ({ id: item.bk_classification_id, name: item.bk_classification_name }))"
                 >
                 </editable-field>

--- a/src/ui/src/views/model-manage/index.vue
+++ b/src/ui/src/views/model-manage/index.vue
@@ -791,7 +791,8 @@
         ]
       },
       toggleModelList(classification) {
-        this.classificationsCollapseState[classification.id] = !this.classificationsCollapseState[classification.id]
+        const val = !this.classificationsCollapseState[classification.id]
+        this.$set(this.classificationsCollapseState, classification.id, val)
       },
       getModelViewAuth(model) {
         return { type: this.$OPERATION.R_MODEL, relation: [model.id] }


### PR DESCRIPTION
### 修复的问题：
- 自定义字段点击分组旁的三个点图标没有反应
- 收藏条件增加基本类型值判断
- 模型详情下选择修改分组，这里应该展示原有的所属分组
