### PR TITLE
fix: 取消前端业务内置字段time_zone默认值设置 --bug=163268690

### DIFF
--- a/src/ui/src/components/ui/form/timezone.vue
+++ b/src/ui/src/components/ui/form/timezone.vue
@@ -92,10 +92,10 @@
     methods: {
       getDefaultValue() {
         let value = this.value || ''
-        if (this.multiple && !value.length) {
-          value = ['Asia/Shanghai']
+        if (this.multiple && value.length) {
+          value = [...value]
         } else {
-          value = value || 'Asia/Shanghai'
+          value = value || ''
         }
         return value
       },


### PR DESCRIPTION
### 优化的功能:
- 取消前端业务模型内置字段'时区'的默认值展示 