### PR TITLE
fix: 多选字段导出excel添加自动换行样式 --bug=163675032

### DIFF
--- a/pkg/excel/style.go
+++ b/pkg/excel/style.go
@@ -22,10 +22,11 @@ import (
 
 // Style excel style
 type Style struct {
-	Fill   *Fill
-	Border []Border
-	Font   *Font
-	NumFmt int
+	Fill      *Fill
+	Border    []Border
+	Font      *Font
+	NumFmt    int
+	Alignment *Alignment
 }
 
 func (s *Style) convert() (*excelize.Style, error) {
@@ -49,12 +50,12 @@ func (s *Style) convert() (*excelize.Style, error) {
 
 	if s.Border != nil {
 		for _, border := range s.Border {
-			excelBorder, err := border.convert()
-			if err != nil {
-				return nil, err
-			}
-			style.Border = append(style.Border, excelBorder)
+			style.Border = append(style.Border, border.convert())
 		}
+	}
+
+	if s.Alignment != nil {
+		style.Alignment = s.Alignment.convert()
 	}
 
 	return style, nil
@@ -73,6 +74,20 @@ type Alignment struct {
 	WrapText        bool
 }
 
+func (a *Alignment) convert() *excelize.Alignment {
+	return &excelize.Alignment{
+		Horizontal:      a.Horizontal,
+		Indent:          a.Indent,
+		JustifyLastLine: a.JustifyLastLine,
+		ReadingOrder:    a.ReadingOrder,
+		RelativeIndent:  a.RelativeIndent,
+		ShrinkToFit:     a.ShrinkToFit,
+		TextRotation:    a.TextRotation,
+		Vertical:        a.Vertical,
+		WrapText:        a.WrapText,
+	}
+}
+
 type borderType string
 
 const (
@@ -89,12 +104,12 @@ type Border struct {
 	Style int
 }
 
-func (b *Border) convert() (excelize.Border, error) {
+func (b *Border) convert() excelize.Border {
 	return excelize.Border{
 		Type:  string(b.Type),
 		Color: b.Color,
 		Style: b.Style,
-	}, nil
+	}
 }
 
 // Font directly maps the font settings of the fonts.

--- a/src/web_server/service/excel/core/object_func.go
+++ b/src/web_server/service/excel/core/object_func.go
@@ -101,7 +101,7 @@ func (d *Client) GetObjColProp(kit *rest.Kit, cond mapstr.MapStr) ([]ColProp, er
 	for idx, attr := range attrs {
 		colProp := ColProp{ID: attr.PropertyID, Name: attr.PropertyName, PropertyType: attr.PropertyType,
 			IsRequire: attr.IsRequired, Option: attr.Option, Group: attr.PropertyGroup, RefSheet: attr.PropertyName,
-			Length: PropertyNormalLen,
+			Length: PropertyNormalLen, IsMultiple: attr.IsMultiple != nil && *attr.IsMultiple,
 		}
 
 		result[idx] = colProp

--- a/src/web_server/service/excel/core/property.go
+++ b/src/web_server/service/excel/core/property.go
@@ -49,6 +49,8 @@ type ColProp struct {
 	RefSheet string
 	// NotEditable 是否不可编辑
 	NotEditable bool
+	// IsMultiple multi-select flag, drives wrap-text on export
+	IsMultiple bool
 }
 
 // GetRowWidth get row width

--- a/src/web_server/service/excel/operator/inst/exporter/inst_func.go
+++ b/src/web_server/service/excel/operator/inst/exporter/inst_func.go
@@ -221,7 +221,9 @@ func getHandleTableFieldFunc() handleInstFieldFunc {
 				}
 
 				colProp := &core.ColProp{ID: attr.PropertyID, Name: attr.PropertyName, PropertyType: attr.PropertyType,
-					IsRequire: attr.IsRequired, Option: attr.Option, Group: attr.PropertyGroup}
+					IsRequire: attr.IsRequired, Option: attr.Option, Group: attr.PropertyGroup,
+					IsMultiple: attr.IsMultiple != nil && *attr.IsMultiple,
+				}
 				rows, err := handleFunc(e, colProp, data[attr.PropertyID])
 				if err != nil {
 					blog.ErrorJSON("handle instance failed, property: %s, val: %s, err: %s, rid: %s", property, val,
@@ -249,7 +251,7 @@ func getDefaultHandleFieldFunc() handleInstFieldFunc {
 		if property.NotEditable {
 			style = noEditField
 		}
-		styleID, err := e.styleCreator.getStyle(style, property.PropertyType)
+		styleID, err := e.styleCreator.getStyle(style, WithPropType(property.PropertyType), WithWrap(property.IsMultiple))
 		if err != nil {
 			return nil, err
 		}

--- a/src/web_server/service/excel/operator/inst/exporter/property_func.go
+++ b/src/web_server/service/excel/operator/inst/exporter/property_func.go
@@ -147,11 +147,11 @@ func getHandleBoolTypeFunc() handleColPropFunc {
 
 func getHandleTableTypeFunc() handleColPropFunc {
 	return func(t *TmplOp, property *core.ColProp) ([][]excel.Cell, error) {
-		nameStyle, err := t.styleCreator.getStyle(firstRow, property.PropertyType)
+		nameStyle, err := t.styleCreator.getStyle(firstRow, WithPropType(property.PropertyType))
 		if err != nil {
 			return nil, err
 		}
-		headerStyle, err := t.styleCreator.getStyle(generalHeader, property.PropertyType)
+		headerStyle, err := t.styleCreator.getStyle(generalHeader, WithPropType(property.PropertyType))
 		if err != nil {
 			return nil, err
 		}
@@ -180,7 +180,9 @@ func getHandleTableTypeFunc() handleColPropFunc {
 
 		for _, attr := range option.Header {
 			colProp := &core.ColProp{ID: attr.PropertyID, Name: attr.PropertyName, PropertyType: attr.PropertyType,
-				IsRequire: attr.IsRequired, Option: attr.Option, Group: attr.PropertyGroup, RefSheet: attr.PropertyName}
+				IsRequire: attr.IsRequired, Option: attr.Option, Group: attr.PropertyGroup, RefSheet: attr.PropertyName,
+				IsMultiple: attr.IsMultiple != nil && *attr.IsMultiple,
+			}
 
 			if colProp.PropertyType == common.FieldTypeEnumMulti {
 				colProp.RefSheet = property.Name + "##" + colProp.Name
@@ -205,7 +207,7 @@ func getHandleTableTypeFunc() handleColPropFunc {
 			result[core.TableIDRowIdx] = append(result[core.TableIDRowIdx], properyResult[core.IDRowIdx]...)
 		}
 
-		tableHeaderStyle, err := t.styleCreator.getStyle(tableHeader, property.PropertyType)
+		tableHeaderStyle, err := t.styleCreator.getStyle(tableHeader, WithPropType(property.PropertyType))
 		if err != nil {
 			return nil, err
 		}
@@ -229,11 +231,11 @@ func getDefaultHandleTypeFunc() handleColPropFunc {
 			headerStyleType = noEditHeader
 		}
 
-		nameStyle, err := t.styleCreator.getStyle(nameStyleType, property.PropertyType)
+		nameStyle, err := t.styleCreator.getStyle(nameStyleType, WithPropType(property.PropertyType))
 		if err != nil {
 			return nil, err
 		}
-		headerStyle, err := t.styleCreator.getStyle(headerStyleType, property.PropertyType)
+		headerStyle, err := t.styleCreator.getStyle(headerStyleType, WithPropType(property.PropertyType))
 		if err != nil {
 			return nil, err
 		}

--- a/src/web_server/service/excel/operator/inst/exporter/style.go
+++ b/src/web_server/service/excel/operator/inst/exporter/style.go
@@ -69,9 +69,11 @@ func init() {
 	createStyleFuncMap[normalField] = getNormalStyleFunc()
 }
 
-type createStyleFunc func(s *styleCreator, numFmt int) (int, error)
+// createStyleFunc builds one excel style. Add new dimensions by extending
+// styleOption + WithXxx; the signature stays unchanged.
+type createStyleFunc func(s *styleCreator, opt styleOption) (int, error)
 
-// handlePropertyTypeNumFmt propType->excel code
+// handlePropertyTypeNumFmt maps property type to excel built-in number-format code.
 func handlePropertyTypeNumFmt(propType string) int {
 	switch propType {
 	case common.FieldTypeInt:
@@ -90,10 +92,18 @@ func handlePropertyTypeNumFmt(propType string) int {
 	}
 }
 
+// wrapAlign returns nil for non-wrap styles (don't emit empty alignment).
+func wrapAlign(opt styleOption) *excel.Alignment {
+	if opt.wrap {
+		return &excel.Alignment{Vertical: "bottom", WrapText: true}
+	}
+	return nil
+}
+
 func getNoEditHeaderStyleFunc() createStyleFunc {
-	return func(s *styleCreator, numFmt int) (int, error) {
+	return func(s *styleCreator, opt styleOption) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: "pattern", Color: []string{noEditHeaderColor}, Pattern: 1},
-			Border: generalBorder, NumFmt: numFmt}
+			Border: generalBorder, NumFmt: handlePropertyTypeNumFmt(opt.propType), Alignment: wrapAlign(opt)}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -105,9 +115,9 @@ func getNoEditHeaderStyleFunc() createStyleFunc {
 }
 
 func getNormalStyleFunc() createStyleFunc {
-	return func(s *styleCreator, numFmt int) (int, error) {
+	return func(s *styleCreator, opt styleOption) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: "pattern", Color: []string{}, Pattern: 1},
-			Border: generalBorder, NumFmt: numFmt}
+			Border: generalBorder, NumFmt: handlePropertyTypeNumFmt(opt.propType), Alignment: wrapAlign(opt)}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -119,9 +129,9 @@ func getNormalStyleFunc() createStyleFunc {
 }
 
 func getNoEditFieldStyleFunc() createStyleFunc {
-	return func(s *styleCreator, numFmt int) (int, error) {
+	return func(s *styleCreator, opt styleOption) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: excel.Pattern, Color: []string{noEditFieldColor}, Pattern: 1},
-			Border: generalBorder, NumFmt: numFmt}
+			Border: generalBorder, NumFmt: handlePropertyTypeNumFmt(opt.propType), Alignment: wrapAlign(opt)}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -133,9 +143,9 @@ func getNoEditFieldStyleFunc() createStyleFunc {
 }
 
 func getFirstRowStyleFunc() createStyleFunc {
-	return func(s *styleCreator, numFmt int) (int, error) {
+	return func(s *styleCreator, opt styleOption) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: excel.Pattern, Color: []string{firstRowColor}, Pattern: 1},
-			Border: generalBorder, NumFmt: numFmt}
+			Border: generalBorder, NumFmt: handlePropertyTypeNumFmt(opt.propType), Alignment: wrapAlign(opt)}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -147,9 +157,9 @@ func getFirstRowStyleFunc() createStyleFunc {
 }
 
 func getGeneralHeaderStyleFunc() createStyleFunc {
-	return func(s *styleCreator, numFmt int) (int, error) {
+	return func(s *styleCreator, opt styleOption) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: excel.Pattern, Color: []string{generalHeaderColor}, Pattern: 1},
-			Border: generalBorder, NumFmt: numFmt}
+			Border: generalBorder, NumFmt: handlePropertyTypeNumFmt(opt.propType), Alignment: wrapAlign(opt)}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -161,9 +171,9 @@ func getGeneralHeaderStyleFunc() createStyleFunc {
 }
 
 func getTableHeaderStyleFunc() createStyleFunc {
-	return func(s *styleCreator, numFmt int) (int, error) {
+	return func(s *styleCreator, opt styleOption) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: excel.Pattern, Color: []string{tableHeaderColor}, Pattern: 1},
-			Border: generalBorder, NumFmt: numFmt}
+			Border: generalBorder, NumFmt: handlePropertyTypeNumFmt(opt.propType), Alignment: wrapAlign(opt)}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -175,9 +185,9 @@ func getTableHeaderStyleFunc() createStyleFunc {
 }
 
 func getExampleStyleFunc() createStyleFunc {
-	return func(s *styleCreator, numFmt int) (int, error) {
+	return func(s *styleCreator, opt styleOption) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: excel.Pattern, Color: []string{exampleColor}, Pattern: 1},
-			Border: generalBorder, NumFmt: numFmt}
+			Border: generalBorder, NumFmt: handlePropertyTypeNumFmt(opt.propType), Alignment: wrapAlign(opt)}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -189,9 +199,10 @@ func getExampleStyleFunc() createStyleFunc {
 }
 
 func getRequiredFieldStyleFunc() createStyleFunc {
-	return func(s *styleCreator, numFmt int) (int, error) {
+	return func(s *styleCreator, opt styleOption) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: excel.Pattern, Color: []string{firstRowColor}, Pattern: 1},
-			Border: generalBorder, Font: &excel.Font{Color: requiredFieldColor}, NumFmt: numFmt}
+			Border: generalBorder, Font: &excel.Font{Color: requiredFieldColor},
+			NumFmt: handlePropertyTypeNumFmt(opt.propType), Alignment: wrapAlign(opt)}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -204,14 +215,21 @@ func getRequiredFieldStyleFunc() createStyleFunc {
 
 type styleCreator struct {
 	excel    *excel.Excel
-	styleMap map[styleType]int
+	styleMap map[styleCacheKey]int
+}
+
+// styleCacheKey is the cache key for a registered excel style.
+type styleCacheKey struct {
+	style    styleType
+	propType string
+	wrap     bool
 }
 
 type styleOperatorFunc func(style *styleCreator) error
 
 func newStyleCreator(opts ...styleOperatorFunc) (*styleCreator, error) {
 	style := &styleCreator{
-		styleMap: make(map[styleType]int),
+		styleMap: make(map[styleCacheKey]int),
 	}
 	for _, opt := range opts {
 		if err := opt(style); err != nil {
@@ -229,21 +247,45 @@ func setExcel(excel *excel.Excel) styleOperatorFunc {
 	}
 }
 
-func (s *styleCreator) getStyle(style styleType, propTypes ...string) (int, error) {
-	result, ok := s.styleMap[style]
-	if !ok {
-		styleFunc := createStyleFuncMap[style]
-		var err error
-		var propType string
-		if len(propTypes) > 0 {
-			propType = propTypes[0]
-		}
-		numFmt := handlePropertyTypeNumFmt(propType)
-		result, err = styleFunc(s, numFmt)
-		if err != nil {
-			return 0, err
-		}
+// styleOption holds every dimension used to compose an excel style.
+type styleOption struct {
+	propType string
+	wrap     bool
+}
+
+// StyleOption mutates a styleOption. Add WithXxx to introduce new dimensions.
+type StyleOption func(*styleOption)
+
+// WithPropType picks the Excel number-format code for the property type.
+func WithPropType(propType string) StyleOption {
+	return func(o *styleOption) {
+		o.propType = propType
+	}
+}
+
+// WithWrap enables wrap-text for multi-select fields, bottom-aligned.
+func WithWrap(wrap bool) StyleOption {
+	return func(o *styleOption) {
+		o.wrap = wrap
+	}
+}
+
+// getStyle returns the style ID, cached per (style, propType, wrap).
+func (s *styleCreator) getStyle(style styleType, opts ...StyleOption) (int, error) {
+	opt := styleOption{}
+	for _, o := range opts {
+		o(&opt)
+	}
+	key := styleCacheKey{style: style, propType: opt.propType, wrap: opt.wrap}
+	if result, ok := s.styleMap[key]; ok {
+		return result, nil
 	}
 
+	styleFunc := createStyleFuncMap[style]
+	result, err := styleFunc(s, opt)
+	if err != nil {
+		return 0, err
+	}
+	s.styleMap[key] = result
 	return result, nil
 }

--- a/src/web_server/service/excel/operator/inst/importer/importer.go
+++ b/src/web_server/service/excel/operator/inst/importer/importer.go
@@ -484,7 +484,9 @@ func (i *Importer) buildPropWithTable(propMap map[string]core.ColProp, idRow []s
 		tableHeaderMap := make(map[string]core.ColProp, len(option.Header))
 		for _, attr := range option.Header {
 			subProp := core.ColProp{ID: attr.PropertyID, Name: attr.PropertyName, PropertyType: attr.PropertyType,
-				Option: attr.Option, IsRequire: attr.IsRequired, Length: core.PropertyNormalLen}
+				Option: attr.Option, IsRequire: attr.IsRequired, Length: core.PropertyNormalLen,
+				IsMultiple: attr.IsMultiple != nil && *attr.IsMultiple,
+			}
 
 			tableHeaderMap[attr.PropertyID] = subProp
 		}


### PR DESCRIPTION
### 优化的功能:
- 若模型字段可多选时（ismultiple:true）, 导出Excel单元格添加默认换行样式（下对齐）
- 封装一层StyleOption方便后续类似功能扩展